### PR TITLE
Tweak the QuickEdit view to work with a 960px width page.

### DIFF
--- a/Products/PloneFormGen/browser/resources/toolbox.css
+++ b/Products/PloneFormGen/browser/resources/toolbox.css
@@ -1,7 +1,7 @@
 /** Widgets manager styles **/
 
 .pfg-form {
-    width: 75%;
+    width: 72.75%;
     float: left;
 }
 


### PR DESCRIPTION
This feels like a hack still, really you want to say that #pfg-form is full width (97.75%) - 210px. Or something like that...
