### PR TITLE
Proposal for QuickEdit to support adding types with spaces in their id

### DIFF
--- a/Products/PloneFormGen/browser/quickedit.py
+++ b/Products/PloneFormGen/browser/quickedit.py
@@ -1,3 +1,5 @@
+from urllib import quote_plus
+
 from Acquisition import aq_inner
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
@@ -28,10 +30,13 @@ class QuickEditView(BrowserView):
     def _addableTypes(self):
         folder_factories = getMultiAdapter((self.context, self.request),
                                            name='folder_factories')
-        return [atype 
-                for atype in folder_factories.addable_types() 
-                if atype['id'] not in ('FieldsetStart', 'FieldsetEnd', 'FieldsetFolder')
-               ]
+        atypes = []
+        blacklist = ('FieldsetStart', 'FieldsetEnd', 'FieldsetFolder')
+        for atype in folder_factories.addable_types():
+            if atype['id'] not in blacklist:
+                atype['id'] = quote_plus(atype['id'])
+                atypes.append(atype)
+        return atypes
 
     def addablePrioritizedFields(self):
         """Return a prioritized list of the addable fields in context"""


### PR DESCRIPTION
When you try really hard, you can create a working portal type (e.g. a PFG form field or adapter) with spaces in its id :-)

Unfortunately, those types cannot be added using PFG's QuickEdit-view (1.7.0), because it cuts the id from the first space and generates broken createObject-link.

Probably this could be also fixed in javascripts. This proposal fixes it by quoting type id in the same way that it's quoted in factory menu's link:

https://github.com/plone/plone.app.content/blob/master/plone/app/content/browser/folderfactories.py#L95
