### PR TITLE
Display viewlets from the ``plone.belowcontenttitle`` manager

### DIFF
--- a/Products/PloneFormGen/skins/PloneFormGen/fg_base_view_p3.cpt
+++ b/Products/PloneFormGen/skins/PloneFormGen/fg_base_view_p3.cpt
@@ -82,6 +82,8 @@
           Title or id
         </h1>
 
+        <div tal:replace="structure provider:plone.belowcontenttitle" />
+
         <p class="documentDescription"
            tal:content="here/Description"
            tal:condition="here/Description">


### PR DESCRIPTION
Currently the `fb_base_view_p3` template does not display the `plone.belowcontenttittle` viewlet manager, which means that viewlets such as `documentByline` are not displayed. This commit fixes this shortcoming.
