### PR TITLE
Fix for the PFG File Field

### DIFF
--- a/Products/PloneFormGen/CHANGES.txt
+++ b/Products/PloneFormGen/CHANGES.txt
@@ -1,6 +1,11 @@
 Change History
 ==============
 
+unreleased
+
+- Fix FileField compatibility with latest Archetypes [do3cc]
+
+
 1.7.4 2012-11-04
 ----------------
 

--- a/Products/PloneFormGen/content/fields.py
+++ b/Products/PloneFormGen/content/fields.py
@@ -1258,6 +1258,18 @@ class FGFileField(BaseFormField):
 
         return self.fgField.getName() + '_file'
 
+    # some File methods to make the FGFileField behave like a file object
+    # this solves an issue with Archetype trying to read the file and 
+    # determine the mime type
+
+    def seek(self, offset, whence=None):
+        return
+
+    def read(self, size=None):
+        return ''
+
+    def tell(self):
+        return 0
 
 registerATCT(FGFileField, PROJECTNAME)
 


### PR DESCRIPTION
PFG File Field now has some basic file methods so it works with the latest Archetypes version

Patch was suggested by do3cc in issue: https://github.com/smcmahon/Products.PloneFormGen/issues/50
