### PR TITLE
Fix incompatibility with LinguaPlone

### DIFF
--- a/Products/PloneFormGen/content/fieldset.py
+++ b/Products/PloneFormGen/content/fieldset.py
@@ -18,7 +18,7 @@ from Products.CMFPlone.utils import safe_hasattr, base_hasattr
 
 from Products.Archetypes.public import *
 
-from plone.app.folder.folder import ATFolderSchema, ATFolder
+from Products.ATContentTypes.content.folder import ATFolderSchema, ATFolder
 
 from Products.ATContentTypes.content.schemata import finalizeATCTSchema
 from Products.ATContentTypes.content.base import registerATCT


### PR DESCRIPTION
If the base class is taken directly from p.a.folder the LP mixin from P.ATContentTypes is not available and fieldsets are not LP aware.
It is done correctly for the FormFolder found in form.py
