### PR TITLE
Fix MaxLengthValidator to only count newlines once.

### DIFF
--- a/Products/PloneFormGen/validators/MaxLengthValidator.py
+++ b/Products/PloneFormGen/validators/MaxLengthValidator.py
@@ -39,7 +39,7 @@ class MaxLengthValidator:
         if maxlength == 0:
             return 1
 
-        nval = len(value)
+        nval = len(value.replace('\r\n', '\n'))
 
         if nval <= maxlength:
             return 1


### PR DESCRIPTION
This request fixes #68.

The javascript counter counts newlines as one character but the value of the field in the python validation script shows newlines as '\r\n'. This request replaces '\r\n' with '\n' for the character count while leaving the original value unchanged. This makes sure that the two counts match.
