### PR TITLE
Fixed type definition for FieldsetStart type

### DIFF
--- a/Products/PloneFormGen/CHANGES.txt
+++ b/Products/PloneFormGen/CHANGES.txt
@@ -4,6 +4,9 @@ Change History
 1.7.13 (unreleased)
 -------------------
 
+- Fixed type definition for FieldsetStart type
+  [naro]
+
 - Depend on Products.CMFPlone instead of Plone.
   [maurits]
 

--- a/Products/PloneFormGen/profiles/default/types/FieldsetStart.xml
+++ b/Products/PloneFormGen/profiles/default/types/FieldsetStart.xml
@@ -7,24 +7,39 @@
  <property name="content_meta_type">FieldsetStart</property>
  <property name="product">PloneFormGen</property>
  <property name="factory">addFGFieldsetStart</property>
- <property name="immediate_view">base_edit</property>
  <property name="global_allow">False</property>
  <property name="filter_content_types">False</property>
  <property name="allowed_content_types"/>
  <property name="allow_discussion">False</property>
- <alias from="(Default)" to="base_view"/>
+ <property name="default_view_fallback">False</property>
+ <property name="immediate_view">base_view</property>
+ <property name="default_view">base_view</property>
+ <property name="view_methods">
+  <element value="base_view"/>
+ </property>
+ <alias from="(Default)" to="(dynamic view)"/>
  <alias from="edit" to="base_edit"/>
+ <alias from="properties" to="base_metadata"/>
+ <alias from="sharing" to="folder_localrole_form"/>
+ <alias from="view" to="(selected layout)"/>
  <action title="View" action_id="view" category="object" condition_expr=""
-    url_expr="string:${object_url}/base_view" visible="True">
+    url_expr="string:${object_url}/view" visible="True">
   <permission value="View"/>
  </action>
- <action title="Edit" action_id="edit" category="object" condition_expr=""
-    url_expr="string:${object_url}/base_edit" visible="True">
+ <action title="Edit" action_id="edit" category="object"
+    condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user"
+    url_expr="string:${object_url}/edit" visible="True">
   <permission value="Modify portal content"/>
  </action>
  <action title="Properties" action_id="metadata" category="object"
-    condition_expr="" url_expr="string:${object_url}/base_metadata"
+    condition_expr="" url_expr="string:${object_url}/properties"
     visible="False">
   <permission value="Modify portal content"/>
+ </action>
+ <action title="References" action_id="references" category="object"
+    condition_expr="object/archetype_tool/has_graphviz"
+    url_expr="string:${object_url}/reference_graph" visible="False">
+  <permission value="Modify portal content"/>
+  <permission value="Review portal content"/>
  </action>
 </object>


### PR DESCRIPTION
The problem was, if you created a new "Fieldset Begin" field, the /view page was wrong. It showed message <zope.traversing.namespace.view object at 0x......> only.

The new type definition for FieldsetStart is copied from FieldsedEnd.xml
