### PR TITLE
Updated edit icon in skins

### DIFF
--- a/Products/PloneFormGen/skins/PloneFormGen/fg_savedata_tabview_p3.pt
+++ b/Products/PloneFormGen/skins/PloneFormGen/fg_savedata_tabview_p3.pt
@@ -53,7 +53,10 @@
                         <td tal:repeat="cell python:row[1]" tal:content="cell">cell</td>
                         <td tal:condition="canEdit" style="text-align: center">
                             <a tal:attributes="href string:${context/absolute_url}/fg_savedata_editview?id:int=${record_id}">
-                                <img src="edit.gif" />
+                                <img src="edit.gif" alt="Edit" 
+                                    tal:define="view nocall:context/@@quickedit;
+                                                icon_ext view/iconExt;" 
+                                    tal:attributes="src string:${portal_url}/edit.$icon_ext">
                             </a>
                         </td>
                         </tal:index>

--- a/Products/PloneFormGen/skins/PloneFormGen/fg_savedata_tabview_p3.pt
+++ b/Products/PloneFormGen/skins/PloneFormGen/fg_savedata_tabview_p3.pt
@@ -54,7 +54,7 @@
                         <td tal:condition="canEdit" style="text-align: center">
                             <a tal:attributes="href string:${context/absolute_url}/fg_savedata_editview?id:int=${record_id}">
                                 <img src="edit.gif" alt="Edit" 
-                                    tal:define="view nocall:context/@@quickedit;
+                                    tal:define="view nocall:context/aq_parent/@@quickedit;
                                                 icon_ext view/iconExt;" 
                                     tal:attributes="src string:${portal_url}/edit.$icon_ext">
                             </a>


### PR DESCRIPTION
as done for browserviews, use edit.png for latest version of plone, but edit.gif for backward compat
this probably could be done in some better way by not using aq_parent...
note: the buildout in the package itself was not working for me, but this fix was tested in another setup