### PR TITLE
Add a Submission Folder Adapter that saves submissions as content in a folder

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,12 @@
 Change History
 ==============
 
-1.7.15 (unreleased)
+1.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add a Submission Folder Adapter that saves submissions as content in a
+  folder.
+  [rpatterson]
 
 
 1.7.14 (2014-01-26)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,12 @@ Change History
 1.8 (unreleased)
 -------------------
 
+- Fix translation support that was overwriting constructor kwargs.
+  [rpatterson]
+
+- Fix attribute error when gpg binary isn't available.
+  [rpatterson]
+
 - Add a Submission Folder Adapter that saves submissions as content in a
   folder.
   [rpatterson]

--- a/Products/PloneFormGen/__init__.py
+++ b/Products/PloneFormGen/__init__.py
@@ -39,7 +39,7 @@ from AccessControl import ModuleSecurityInfo
 from Products.PloneFormGen.config import PROJECTNAME, \
     ADD_CONTENT_PERMISSION, CSA_ADD_CONTENT_PERMISSION, \
     MA_ADD_CONTENT_PERMISSION, SDA_ADD_CONTENT_PERMISSION, \
-    SKINS_DIR, GLOBALS
+    SFA_ADD_CONTENT_PERMISSION, SKINS_DIR, GLOBALS
 
 registerDirectory(SKINS_DIR + '/PloneFormGen', GLOBALS)
 
@@ -78,6 +78,8 @@ def initialize(context):
             permission = MA_ADD_CONTENT_PERMISSION
         elif atype.portal_type == 'FormSaveDataAdapter':
             permission = SDA_ADD_CONTENT_PERMISSION
+        elif atype.portal_type == 'FormSubmissionFolderAdapter':
+            permission = SFA_ADD_CONTENT_PERMISSION
         else:
             permission = ADD_CONTENT_PERMISSION
         utils.ContentInit(

--- a/Products/PloneFormGen/config.py
+++ b/Products/PloneFormGen/config.py
@@ -167,6 +167,7 @@ fieldTypes = (
 
 adapterTypes = (
     'FormSaveDataAdapter',
+    'FormSubmissionFolderAdapter',
     'FormMailerAdapter',
     'FormCustomScriptAdapter',
 )
@@ -188,6 +189,8 @@ MA_ADD_CONTENT_PERMISSION = 'PloneFormGen: Add Mailers'
 setDefaultRoles(MA_ADD_CONTENT_PERMISSION, ('Manager','Owner','Site Administrator'))
 SDA_ADD_CONTENT_PERMISSION = 'PloneFormGen: Add Data Savers'
 setDefaultRoles(SDA_ADD_CONTENT_PERMISSION, ('Manager','Owner','Site Administrator'))
+SFA_ADD_CONTENT_PERMISSION = 'PloneFormGen: Add Submission Folders'
+setDefaultRoles(SFA_ADD_CONTENT_PERMISSION, ('Manager','Owner','Site Administrator'))
 CSA_ADD_CONTENT_PERMISSION = 'PloneFormGen: Add Custom Scripts'
 setDefaultRoles(CSA_ADD_CONTENT_PERMISSION, ('Manager',))
 
@@ -220,6 +223,7 @@ pfgPermitList = [
     ADD_CONTENT_PERMISSION,
     MA_ADD_CONTENT_PERMISSION,
     SDA_ADD_CONTENT_PERMISSION,
+    SFA_ADD_CONTENT_PERMISSION,
     CSA_ADD_CONTENT_PERMISSION,
     EDIT_TALES_PERMISSION,
     EDIT_PYTHON_PERMISSION,

--- a/Products/PloneFormGen/configure.zcml
+++ b/Products/PloneFormGen/configure.zcml
@@ -69,6 +69,9 @@
       class=".content.saveDataAdapter.FormSaveDataAdapter" />
 
   <five:deprecatedManageAddDelete
+      class=".content.submissionFolderAdapter.FormSubmissionFolderAdapter" />
+
+  <five:deprecatedManageAddDelete
       class=".content.formLikertField.FGLikertField" />
 
   <!-- exportimport -->
@@ -133,5 +136,8 @@
 
   <subscriber handler=".events.form_adapter_pasted" />
   <subscriber handler=".events.form_adapter_moved" />
+  
+  <adapter factory=".content.submissionFolderAdapter.FormSubmissionModifier"
+           name="form_submission_modifier" />
 
 </configure>

--- a/Products/PloneFormGen/content/__init__.py
+++ b/Products/PloneFormGen/content/__init__.py
@@ -6,6 +6,6 @@
 """
 import fields, form, fieldset
 import actionAdapter, saveDataAdapter, formMailerAdapter
-import customScriptAdapter
+import customScriptAdapter, submissionFolderAdapter
 import thanksPage
 import likertField, formLikertField

--- a/Products/PloneFormGen/content/customScriptAdapter.py
+++ b/Products/PloneFormGen/content/customScriptAdapter.py
@@ -117,9 +117,6 @@ class FormCustomScriptAdapter(FormActionAdapter):
 
     content_icon   = 'scriptaction.gif'
 
-    #immediate_view = 'fg_savedata_view'
-    #default_view   = 'fg_savedata_view'
-
     security = ClassSecurityInfo()
 
     def __init__(self, oid, **kwargs):

--- a/Products/PloneFormGen/content/form.py
+++ b/Products/PloneFormGen/content/form.py
@@ -683,6 +683,17 @@ class FormFolder(ATFolder):
             # traversal will work fine
             return 'traverse_to:string:%s' % target
 
+    def setActionAdapter(self, value):
+        """
+        Preserve folder order when setting the action adapters.
+        """
+        if isinstance(value, (str, unicode)):
+            value = [value]
+        sorted_value = sorted(
+            value,
+            key=lambda adapter: adapter in self and self.getObjectPosition)
+        self.getField('actionAdapter').set(self, sorted_value)
+
     def getRawActionAdapter(self):
         """ Returns selected action adapters as tuple """
 
@@ -721,7 +732,7 @@ class FormFolder(ATFolder):
         aa = set(list(self.getRawActionAdapter())) # use sets to avoid duplicates
         if id not in aa:
             aa.add(id.decode(self.getCharset()))
-        self.actionAdapter = list(aa)
+        self.setActionAdapter(aa)
 
 
     security.declareProtected(ModifyPortalContent, 'fgFieldsDisplayList')
@@ -1033,7 +1044,7 @@ class FormFolder(ATFolder):
             work.remove(item_id)
         else:
             work.add(item_id)
-        self.actionAdapter = list(work)
+        self.setActionAdapter(work)
         return "<done />"
 
     security.declareProtected(ModifyPortalContent, 'setThanksPageTTW')

--- a/Products/PloneFormGen/content/form.py
+++ b/Products/PloneFormGen/content/form.py
@@ -824,8 +824,12 @@ class FormFolder(ATFolder):
 
         ATFolder.initializeArchetype(self, **kwargs)
 
-        self.setSubmitLabel(zope.i18n.translate(_(u'pfg_formfolder_submit', u'Submit'), context=self.REQUEST))
-        self.setResetLabel(zope.i18n.translate(_(u'pfg_formfolder_reset', u'Reset'), context=self.REQUEST))
+        if 'submitLabel' not in kwargs:
+            self.setSubmitLabel(zope.i18n.translate(
+                _(u'pfg_formfolder_submit', u'Submit'), context=self.REQUEST))
+        if 'resetLabel' not in kwargs:
+            self.setResetLabel(zope.i18n.translate(
+                _(u'pfg_formfolder_reset', u'Reset'), context=self.REQUEST))
 
         oids = self.objectIds()
 

--- a/Products/PloneFormGen/content/form.py
+++ b/Products/PloneFormGen/content/form.py
@@ -690,8 +690,8 @@ class FormFolder(ATFolder):
         if isinstance(value, (str, unicode)):
             value = [value]
         sorted_value = sorted(
-            value,
-            key=lambda adapter: adapter in self and self.getObjectPosition)
+            value, key=lambda adapter:
+            adapter in self and self.getObjectPosition(adapter))
         self.getField('actionAdapter').set(self, sorted_value)
 
     def getRawActionAdapter(self):

--- a/Products/PloneFormGen/content/formMailerAdapter.py
+++ b/Products/PloneFormGen/content/formMailerAdapter.py
@@ -752,13 +752,12 @@ class FormMailerAdapter(FormActionAdapter):
         if isinstance(body, unicode):
             body = body.encode(self.getCharset())
 
-        keyid = self.getGPGKeyId()
-        encryption = gpg and keyid
-
-        if encryption:
-            bodygpg = gpg.encrypt(body, keyid)
-            if bodygpg.strip():
-                body = bodygpg
+        if gpg:
+            keyid = self.getGPGKeyId()
+            if keyid:
+                bodygpg = gpg.encrypt(body, keyid)
+                if bodygpg.strip():
+                    body = bodygpg
 
         return body
 

--- a/Products/PloneFormGen/content/submissionFolderAdapter.py
+++ b/Products/PloneFormGen/content/submissionFolderAdapter.py
@@ -347,7 +347,7 @@ class FormSubmissionModifier(object):
             'titleField'].get(adapters[0]) or 'title'
         showFields = adapters[0].Schema()['showFields'].get(adapters[0])
         visible = set()
-        for fg_field in form.fgFields():
+        for fg_field in form.fgFields(excludeServerSide=False):
             if showFields and fg_field.__name__ not in showFields:
                 continue
             field = fg_field.copy()
@@ -358,6 +358,7 @@ class FormSubmissionModifier(object):
             schema[field.__name__] = field
 
             # Generate accessor/mutator methods for use in views
+            field.accessor = field.edit_accessor = field.mutator = None
             for mode in self.modes.itervalues():
                 attr = 'get{0}{1}'.format(
                     mode['attr'][0].capitalize(), mode['attr'][1:])
@@ -390,6 +391,10 @@ class FormSubmissionModifier(object):
     
                     return instanceMethod
                 setattr(field, attr, fieldMethod)
+
+            if not isinstance(field.widget.visible, dict):
+                field.widget.visible = dict()
+            field.widget.visible['view'] = 'visible'
 
         for field in schema.filterFields(isMetadata=0):
             if field.__name__ in visible:

--- a/Products/PloneFormGen/content/submissionFolderAdapter.py
+++ b/Products/PloneFormGen/content/submissionFolderAdapter.py
@@ -1,0 +1,400 @@
+"""
+A form action adapter that saves form submissions as content in a folder.
+"""
+
+__author__ = 'Ross Patterson <me@rpatterson.net>'
+__docformat__ = 'plaintext'
+
+import copy
+import logging
+
+from zope import interface
+from zope import component
+
+from plone.i18n.normalizer import interfaces as norm_ifaces
+
+from AccessControl import ClassSecurityInfo
+from AccessControl import getSecurityManager
+from AccessControl.SecurityManagement import newSecurityManager
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+
+from Products.CMFCore import WorkflowCore
+from Products.CMFCore.utils import getToolByName
+
+from archetypes.schemaextender import interfaces as extender_ifaces
+from archetypes.schemaextender import extender
+from Products.Archetypes import BaseObject
+from Products.Archetypes import ClassGen
+from Products.Archetypes import public
+from Products.ATContentTypes.content import base
+from Products.ATContentTypes.content import folder
+
+from Products.PloneFormGen import config
+from Products.PloneFormGen import PloneFormGenMessageFactory as _
+from Products.PloneFormGen.content import saveDataAdapter
+
+logger = logging.getLogger("PloneFormGen")
+
+
+class IFormSubmission(interface.Interface):
+    """
+    A saved form submission whose schema is extended with the form schema.
+    """
+
+
+class FormSubmissionFolderAdapter(
+        folder.ATFolder, saveDataAdapter.FormSaveDataAdapter):
+    """
+    A form action adapter that saves form submissions as content in a folder.
+    """
+
+    schema = folder.ATFolder.schema.copy(
+    ) + public.Schema((
+        saveDataAdapter.FormSaveDataAdapter.schema['showFields'].copy(),
+        public.StringField(
+            'titleField',
+            vocabulary='allFieldDisplayList',
+            default_method='getDefaultTitleField',
+            required=0,
+            searchable=0,
+            widget=public.SelectionWidget(
+                label=_(u'label_titlefield_text', default=u"Title Field"),
+                description=_(
+                    u'help_titlefield_text', default=u"""\
+You may select a form field to be used as the submissions Plone title.  If left
+empty, the title will be left blank."""))),
+        public.StringField(
+            'submissionType',
+            required=0,
+            searchable=0,
+            default='Document',
+            vocabulary='getFolderAddableTypes',
+            widget=public.SelectionWidget(
+                label=_(u'label_submissiontype_text',
+                        default=u"Submission Type"),
+                description=_(
+                    u'help_submissiontype_text', default=u"""\
+You may select another content type to create for form submissions.  Note that
+the content type's schema will be overridden by the schema defined by the form,
+so choosing a non-default content type will only work as much as the form
+schema matches the content type's schema"""))),
+        public.ReferenceField(
+            'submissionFolder',
+            relationship='submissionFolder',
+            allowed_types_method='getFolderishTypes',
+            default_method='getSubmissionFolderDefault',
+            required=0,
+            searchable=0,
+            widget=public.ReferenceWidget(
+                label=_(u'label_submissionfolder_text',
+                        default=u"Submission Folder"),
+                description=_(
+                    u'help_submissionfolder_text', default=u"""\
+You may select a folder in which submissions will be saved.  If left blank,
+submissions will be saved inside this adapter."""))),
+        public.LinesField(
+            'submissionTransitions',
+            default=['hide'],
+            vocabulary='getAvilableSubmissionTransitions',
+            widget=public.PicklistWidget(
+                label=_(u'label_submissiontransitions_text',
+                        default='Submission Workflow Transitions'),
+                description=_(u'help_submissiontransitions_text', default=u"""\
+Select a sequence of workflow transitions to be applied on the newly created
+submission object.  If the Submission Type workflow doesn't start out in a
+private state, it is important to choose the right transitons to keep form
+submissions from being publicly available."""))),
+    ))
+
+    meta_type      = 'FormSubmissionFolderAdapter'
+    portal_type    = 'FormSubmissionFolderAdapter'
+    archetype_name = 'Submission Folder Adapter'
+
+    immediate_view = default_view = 'folder_listing'
+    suppl_views    = ('folder_contents', )
+
+    security       = ClassSecurityInfo()
+
+    security.declarePrivate('onSuccess')
+    def onSuccess(self, fields, REQUEST, loopstop=False):
+        """
+        Add a Form Submission object to the folder on success.
+
+        Manually check if the user has permission.  If anonymous users have
+        permissions to add submissions, then make sure the submission is owned
+        by the adapter owner to prevent security issues such as various
+        anonymous users accessing each others submissions.
+        """
+        folder = self.getSubmissionFolder()
+        portal_type = self.getSubmissionType()
+        types = getToolByName(self, 'portal_types')
+        allowed = types[portal_type].isConstructionAllowed(folder)
+        
+        membership = getToolByName(self, 'portal_membership')
+        user = getSecurityManager().getUser()
+        owner = self.getWrappedOwner()
+        is_anon = membership.isAnonymousUser()
+        try:
+            if not allowed or is_anon:
+                newSecurityManager(REQUEST, owner)
+            submission, changed = self.addSubmission(
+                REQUEST, folder, portal_type)
+        finally:
+            if not allowed or is_anon:
+                newSecurityManager(REQUEST, user)
+
+        if not allowed and not is_anon:
+            submission.changeOwnership(user, recursive=1)
+            submission.manage_setLocalRoles(user.getId(), ('Owner', ))
+        
+        if 'controller_state' in REQUEST:
+            # Record the submission object where the CMFFormController
+            # machinery can get at it.
+            REQUEST['controller_state'].kwargs.update(**changed)
+            REQUEST['form_submission'] = '/'.join(submission.getPhysicalPath())
+
+    def addSubmission(self, REQUEST, folder, portal_type):
+        """
+        Perform content operations as the appropriate user.
+        """
+        form = aq_parent(aq_inner(self))
+        if folder is None:
+            folder = self
+        order = folder.getOrdering()
+        if not hasattr(order, '__contains__'):
+            order = folder.contentIds()
+
+        title_field_name = self.getTitleField() or 'title'
+        changed = {}
+        if title_field_name in form:
+            # Get the title from a form field in the submission
+            title_field = form[title_field_name]
+            title, kwargs = title_field.fgField.widget.process_form(
+                title_field, title_field.fgField, REQUEST.form)
+            changed[title_field_name] = title
+        else:
+            # Generate a title from the form title
+            title = '{0} Submission'.format(form.Title())
+
+        # Generate an id from the title, adding a suffix if existing
+        id_ = str(norm_ifaces.IUserPreferredURLNormalizer(
+            REQUEST).normalize(title))
+        if id_ in order:
+            # Exising objects have the id, find the next index suffix
+            order_idx = len(folder) - 1
+            base_id = id_
+            idx = 0
+            while id_ in order:
+                while order_idx >= 0:
+                    # Start at the end to try and find the highest index
+                    order_id = order[order_idx]
+                    if order_id.startswith(base_id + '-'):
+                        idx = int(order_id[len(base_id + '-'):])
+                        break
+                    order_idx -= 1
+                id_ = '{0}-{1}'.format(base_id, (idx + 1))
+
+        new_id = folder.invokeFactory(portal_type, id_, title=title)
+        submission = folder[new_id]
+        submission.addReference(self, relationship='submissionFolderAdapter')
+
+        # Mark the item as a form submission so the schema is extended with the
+        # form schema
+        interface.alsoProvides(submission, IFormSubmission)
+        # Set the submission field values now that the extender applies
+        extender.disableCache(REQUEST)
+        schema = submission.Schema()
+        for field in schema.fields():
+            if field.__name__ in ('id', 'title'):
+                # skip factory arguments
+                continue
+            result = field.widget.process_form(
+                submission, field, REQUEST.form,
+                empty_marker=BaseObject._marker,
+                validating=False)
+            if result is BaseObject._marker or result is None:
+                continue
+            changed[field.__name__] = result[0]
+            if field.__name__ in ('id', 'title'):
+                # already set in the factory
+                continue
+            field.set(submission, result[0], **result[1])
+
+        # Apply workflow transitions
+        workflow = getToolByName(submission, 'portal_workflow')
+        for transition in self.getSubmissionTransitions():
+            try:
+                workflow.doActionFor(submission, transition)
+            except WorkflowCore.WorkflowException:
+                logger.exception(
+                    'Workflow transition {0!r} failed on form submission: {1}'
+                    .format(transition, self.absolute_url))
+
+        submission.setLayout('base_view')
+
+        return submission, changed
+                
+    security.declarePrivate('setDefaults')
+    def getDefaultTitleField(self):
+        """
+        Use the first form field as the default title field.
+        """
+        form = aq_parent(aq_inner(self))
+        return form.fgFields()[0].__name__
+
+    security.declarePrivate('setDefaults')
+    def getSubmissionFolderDefault(self):
+        """
+        Use the adapter itself as the default submission folder.
+        """
+        return self
+
+    # TODO Currently there is a chicken and egg between finding out which types
+    # can be added to the submission folder before we select the submission
+    # folder and also which workflow transitions are available for the type.
+    # In the future it would be nice to have AJAX support for updating the
+    # other when one changes.
+
+    security.declarePrivate('setDefaults')
+    def getFolderishTypes(self, instance):
+        """
+        List all portal types that allow creating the submission type.
+        """
+        types = getToolByName(self, 'portal_types')
+        return [self.getPortalTypeName()] + [
+            typeinfo.getId() for typeinfo in types.objectValues()
+            if typeinfo.global_allow and not typeinfo.filter_content_types]
+    
+    security.declarePrivate('setDefaults')
+    def getFolderAddableTypes(self):
+        """
+        Return the allowed form submission types.
+        """
+        # TODO See above
+        # return self.getSubmissionFolder().allowedContentTypes()
+
+        types = getToolByName(self, 'portal_types')
+        return [
+            (typeinfo.getId(), typeinfo.title_or_id())
+            for typeinfo in types.objectValues() if typeinfo.global_allow]
+
+    security.declarePrivate('setDefaults')
+    def getAvilableSubmissionTransitions(self):
+        """
+        List all the possible transitions for the submission type's workflow.
+        """
+        workflow = getToolByName(self, 'portal_workflow')
+
+        workflows = set()
+        workflows.update(*[
+            workflow.getChainForPortalType(portal_type)
+            for portal_type in self.Vocabulary('submissionType')[0].keys()])
+
+        # TODO See above
+        # workflows = workflow.getChainForPortalType(self.getSubmissionType())
+
+        transitions = {}
+        for workflow_id in workflows:
+            workflow_obj = workflow[workflow_id]
+            for state in workflow_obj.states.objectValues():
+                for transition in workflow_obj.transitions.objectValues():
+                    transitions[transition.getId()] = (
+                        transition.actbox_name or transition.title_or_id())
+        return transitions.items()
+        
+
+base.registerATCT(FormSubmissionFolderAdapter, config.PROJECTNAME)
+
+
+class FormSubmissionModifier(object):
+    """
+    Extend form submissions with 
+    """
+
+    interface.implements(extender_ifaces.ISchemaModifier)
+    component.adapts(IFormSubmission)
+
+    modes = copy.deepcopy(ClassGen._modes)
+    modes['m']['attr'] = 'editAccessor'
+
+    def __init__(self, context):
+        self.context = context
+
+    def fiddle(self, schema):
+        if not hasattr(self.context, 'aq_base'):
+            # Some permissions checks invoke the schema on an unwrapped object
+            return
+
+        try:
+            adapters = self.context.getReferences(
+                relationship='submissionFolderAdapter')
+        except AttributeError:
+            # Don't extend the schema when the reference isn't available
+            # Such as when doing CMFEditions stuff
+            return
+        if not adapters:
+            logger.error(
+                'Missing submission form reference, '
+                'cannot look up form schema')
+            return
+        elif len(adapters) != 1:
+            logger.error(
+                'Other than one submission form reference, '
+                'looking up the form schema from the first one: {0}'.format(
+                    adapters))
+        form = aq_parent(aq_inner(adapters[0]))
+        title_field = adapters[0].Schema()[
+            'titleField'].get(adapters[0]) or 'title'
+        showFields = adapters[0].Schema()['showFields'].get(adapters[0])
+        visible = set()
+        for fg_field in form.fgFields():
+            if showFields and fg_field.__name__ not in showFields:
+                continue
+            field = fg_field.copy()
+            if field.__name__ == title_field:
+                field.__name__ = 'title'
+            else:
+                visible.add(field.__name__)
+            schema[field.__name__] = field
+
+            # Generate accessor/mutator methods for use in views
+            for mode in self.modes.itervalues():
+                attr = 'get{0}{1}'.format(
+                    mode['attr'][0].capitalize(), mode['attr'][1:])
+                method = getattr(field, attr)(self.context)
+                if method:
+                    continue
+
+                def fieldMethod(instance, field=field, mode=mode, **kw):
+                    """
+                    Generate an AT field method.
+                    """
+                    if mode['attr'] == 'mutator':
+                        def instanceMethod(
+                                value, field=field, instance=instance,
+                                mode=mode, **kw):
+                            """
+                            Work with an AT field value.
+                            """
+                            field_method = getattr(field, mode['prefix'])
+                            return field_method(instance, value, **kw)
+                    else:
+                        def instanceMethod(
+                                field=field, instance=instance, mode=mode,
+                                **kw):
+                            """
+                            Work with an AT field value.
+                            """
+                            field_method = getattr(field, mode['prefix'])
+                            return field_method(instance, **kw)
+    
+                    return instanceMethod
+                setattr(field, attr, fieldMethod)
+
+            for field in schema.filterFields(isMetadata=0):
+                if field.__name__ in visible:
+                    continue
+                if not isinstance(field.widget.visible, dict):
+                    field.widget.visible = dict()
+                field.widget.visible['view'] = 'invisible'

--- a/Products/PloneFormGen/content/submissionFolderAdapter.py
+++ b/Products/PloneFormGen/content/submissionFolderAdapter.py
@@ -151,7 +151,11 @@ submissions from being publicly available."""))),
             # Record the submission object where the CMFFormController
             # machinery can get at it.
             REQUEST['controller_state'].kwargs.update(**changed)
-            REQUEST['form_submission'] = '/'.join(submission.getPhysicalPath())
+
+            # Use the catalog brain for anonymous access in TAL expressions
+            catalog = getToolByName(self, 'portal_catalog')
+            REQUEST['form_submission'] = catalog._catalog[
+                catalog.getrid('/'.join(submission.getPhysicalPath()))]
 
     def addSubmission(self, REQUEST, folder, portal_type):
         """

--- a/Products/PloneFormGen/content/submissionFolderAdapter.py
+++ b/Products/PloneFormGen/content/submissionFolderAdapter.py
@@ -95,7 +95,6 @@ You may select a folder in which submissions will be saved.  If left blank,
 submissions will be saved inside this adapter."""))),
         public.LinesField(
             'submissionTransitions',
-            default=['hide'],
             vocabulary='getAvilableSubmissionTransitions',
             widget=public.PicklistWidget(
                 label=_(u'label_submissiontransitions_text',

--- a/Products/PloneFormGen/content/submissionFolderAdapter.py
+++ b/Products/PloneFormGen/content/submissionFolderAdapter.py
@@ -391,9 +391,9 @@ class FormSubmissionModifier(object):
                     return instanceMethod
                 setattr(field, attr, fieldMethod)
 
-            for field in schema.filterFields(isMetadata=0):
-                if field.__name__ in visible:
-                    continue
-                if not isinstance(field.widget.visible, dict):
-                    field.widget.visible = dict()
-                field.widget.visible['view'] = 'invisible'
+        for field in schema.filterFields(isMetadata=0):
+            if field.__name__ in visible:
+                continue
+            if not isinstance(field.widget.visible, dict):
+                field.widget.visible = dict()
+            field.widget.visible['view'] = 'invisible'

--- a/Products/PloneFormGen/profiles/default/archetype_tool.xml
+++ b/Products/PloneFormGen/profiles/default/archetype_tool.xml
@@ -100,6 +100,9 @@
   <type portal_type="FormSaveDataAdapter">
    <catalog value="portal_catalog"/>
   </type>
+  <type portal_type="FormSubmissionFolderAdapter">
+   <catalog value="portal_catalog"/>
+  </type>
   <type portal_type="FormThanksPage">
    <catalog value="portal_catalog"/>
   </type>

--- a/Products/PloneFormGen/profiles/default/factorytool.xml
+++ b/Products/PloneFormGen/profiles/default/factorytool.xml
@@ -15,6 +15,7 @@
   <type portal_type="FormThanksPage"/>
   <type portal_type="FormBooleanField"/>
   <type portal_type="FormSaveDataAdapter"/>
+  <type portal_type="FormSubmissionFolderAdapter"/>
   <type portal_type="FormLabelField"/>
   <type portal_type="FormDateField"/>
   <type portal_type="FormIntegerField"/>

--- a/Products/PloneFormGen/profiles/default/metadata.xml
+++ b/Products/PloneFormGen/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>171</version>
+  <version>180</version>
   <dependencies>
       <dependency>profile-plone.app.jquerytools:default</dependency>
       <dependency>profile-collective.js.jqueryui:default</dependency>

--- a/Products/PloneFormGen/profiles/default/propertiestool.xml
+++ b/Products/PloneFormGen/profiles/default/propertiestool.xml
@@ -18,6 +18,7 @@
    <element value="FormFileField"/>
    <element value="FormLikertField"/>
    <element value="FormSaveDataAdapter"/>
+   <element value="FormSubmissionFolderAdapter"/>
    <element value="FormMailerAdapter"/>
    <element value="FormCustomScriptAdapter"/>
    <element value="FormThanksPage"/>
@@ -76,6 +77,7 @@
    <element value="FormFileField"/>
    <element value="FormLikertField"/>
    <element value="FormSaveDataAdapter"/>
+   <element value="FormSubmissionFolderAdapter"/>
    <element value="FormMailerAdapter"/>
    <element value="FormCustomScriptAdapter"/>
    <element value="FormThanksPage"/>

--- a/Products/PloneFormGen/profiles/default/types.xml
+++ b/Products/PloneFormGen/profiles/default/types.xml
@@ -36,6 +36,8 @@
     meta_type="Factory-based Type Information with dynamic views"/>
  <object name="FormSaveDataAdapter"
     meta_type="Factory-based Type Information with dynamic views"/>
+ <object name="FormSubmissionFolderAdapter"
+    meta_type="Factory-based Type Information with dynamic views"/>
  <object name="FormSelectionField"
     meta_type="Factory-based Type Information with dynamic views"/>
  <object name="FormStringField"

--- a/Products/PloneFormGen/profiles/default/types/FormFolder.xml
+++ b/Products/PloneFormGen/profiles/default/types/FormFolder.xml
@@ -35,6 +35,7 @@
   <element value="FormFileField"/>
   <element value="FormLikertField"/>
   <element value="FormSaveDataAdapter"/>
+  <element value="FormSubmissionFolderAdapter"/>
   <element value="FormMailerAdapter"/>
   <element value="FormCustomScriptAdapter"/>
   <element value="FormThanksPage"/>

--- a/Products/PloneFormGen/profiles/default/types/FormSubmissionFolderAdapter.xml
+++ b/Products/PloneFormGen/profiles/default/types/FormSubmissionFolderAdapter.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<object name="FormSubmissionFolderAdapter"
+   meta_type="Factory-based Type Information with dynamic views"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+   i18n:domain="ploneformgen">
+  <property name="title" i18n:translate="Submission Folder Adapter">
+    Submission Folder Adapter
+  </property>
+  <property name="description" i18n:translate="">
+    A form action adapter that is a folder and saves submissions as content in
+    a folder.  To have logged-in users be redirected to the saved submission,
+    set the "Custom Success Action" field in the "Overrides" tab of the Form
+    Folder's edit form to "redirect_to:python:member is not None and
+    request['form_submission'] or 'fg_result_view'"
+  </property>
+  <property name="content_icon">FormAction.gif</property>
+  <property name="content_meta_type">FormSubmissionFolderAdapter</property>
+  <property name="product">PloneFormGen</property>
+  <property name="factory">addFormSubmissionFolderAdapter</property>
+  <property name="immediate_view">folder_listing</property>
+  <property name="global_allow">False</property>
+  <property name="filter_content_types">False</property>
+  <property name="allowed_content_types"/>
+  <property name="allow_discussion">False</property>
+  <property name="default_view">folder_listing</property>
+  <property name="view_methods">
+    <element value="folder_summary_view"/>
+    <element value="folder_full_view"/>
+    <element value="folder_tabular_view"/>
+    <element value="atct_album_view"/>
+    <element value="folder_listing"/>
+  </property>
+  <property name="default_view_fallback">False</property>
+  <alias from="(Default)" to="(dynamic view)"/>
+  <alias from="edit" to="base_edit"/>
+  <alias from="properties" to="base_metadata"/>
+  <alias from="sharing" to="folder_localrole_form"/>
+  <alias from="view" to="(selected layout)"/>
+  <action title="View" action_id="view" category="object" condition_expr=""
+          url_expr="string:${object_url}/view" visible="True">
+    <permission value="View"/>
+  </action>
+  <action title="Edit" action_id="edit" category="object"
+          condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user"
+          url_expr="string:${object_url}/edit" visible="True">
+    <permission value="Modify portal content"/>
+  </action>
+  <action title="Properties" action_id="metadata" category="object"
+          condition_expr="" url_expr="string:${object_url}/properties"
+          visible="False">
+    <permission value="Modify portal content"/>
+  </action>
+  <action title="References" action_id="references" category="object"
+          condition_expr="object/archetype_tool/has_graphviz"
+          url_expr="string:${object_url}/reference_graph" visible="False">
+    <permission value="Modify portal content"/>
+    <permission value="Review portal content"/>
+  </action>
+</object>

--- a/Products/PloneFormGen/profiles/default/types/FormSubmissionFolderAdapter.xml
+++ b/Products/PloneFormGen/profiles/default/types/FormSubmissionFolderAdapter.xml
@@ -11,7 +11,7 @@
     a folder.  To have logged-in users be redirected to the saved submission,
     set the "Custom Success Action" field in the "Overrides" tab of the Form
     Folder's edit form to "redirect_to:python:member is not None and
-    request['form_submission'] or 'fg_result_view'"
+    request['form_submission'].getPath() or 'fg_result_view'"
   </property>
   <property name="content_icon">FormAction.gif</property>
   <property name="content_meta_type">FormSubmissionFolderAdapter</property>

--- a/Products/PloneFormGen/profiles/default/workflows.xml
+++ b/Products/PloneFormGen/profiles/default/workflows.xml
@@ -52,6 +52,9 @@
   <type type_id="FormSaveDataAdapter"/>
  </bindings>
  <bindings>
+  <type type_id="FormSubmissionFolderAdapter"/>
+ </bindings>
+ <bindings>
   <type type_id="FormMailerAdapter"/>
  </bindings>
  <bindings>

--- a/Products/PloneFormGen/tests/testEvents.py
+++ b/Products/PloneFormGen/tests/testEvents.py
@@ -15,6 +15,7 @@ class TestAdapterPaste(pfgtc.PloneFormGenTestCase):
 
     adapterTypes = (
         'FormSaveDataAdapter',
+        'FormSubmissionFolderAdapter',
         'FormMailerAdapter',
         'FormCustomScriptAdapter',
     )

--- a/Products/PloneFormGen/tests/testExportImport.py
+++ b/Products/PloneFormGen/tests/testExportImport.py
@@ -15,6 +15,7 @@ from transaction import commit
 from StringIO import StringIO
 
 from zope.component import getMultiAdapter
+from zope.site.hooks import setSite
 
 from Products.Five import zcml
 from Products.Five import fiveconfigure
@@ -58,6 +59,7 @@ class TestFormGenGSLayer(PloneSite):
         from AccessControl.SecurityManagement import newSecurityManager, noSecurityManager
         user = portal.getWrappedOwner()
         newSecurityManager(None, user)
+        setSite(portal)
 
         portal_setup = portal.portal_setup
 

--- a/Products/PloneFormGen/tests/testSetup.py
+++ b/Products/PloneFormGen/tests/testSetup.py
@@ -60,6 +60,7 @@ class TestInstallation(pfgtc.PloneFormGenTestCase):
         self.fieldTypes = tuple(fieldTypes)
         self.adapterTypes = (
             'FormSaveDataAdapter',
+            'FormSubmissionFolderAdapter',
             'FormMailerAdapter',
             'FormCustomScriptAdapter',
         )
@@ -112,10 +113,14 @@ class TestInstallation(pfgtc.PloneFormGenTestCase):
         CSA_ADD_CONTENT_PERMISSION = 'PloneFormGen: Add Custom Scripts'
         MA_ADD_CONTENT_PERMISSION = 'PloneFormGen: Add Mailers'
         SDA_ADD_CONTENT_PERMISSION = 'PloneFormGen: Add Data Savers'
+        SFA_ADD_CONTENT_PERMISSION = 'PloneFormGen: Add Submission Folders'
 
         self.assertEqual( getAddPermission('PloneFormGen', 'Form Folder'), ADD_CONTENT_PERMISSION)
         self.assertEqual( getAddPermission('PloneFormGen', 'Mailer Adapter'), MA_ADD_CONTENT_PERMISSION)
         self.assertEqual( getAddPermission('PloneFormGen', 'Save Data Adapter'), SDA_ADD_CONTENT_PERMISSION)
+        self.assertEqual(
+            getAddPermission('PloneFormGen', 'Submission Folder Adapter'),
+            SFA_ADD_CONTENT_PERMISSION)
         self.assertEqual( getAddPermission('PloneFormGen', 'Custom Script Adapter'), CSA_ADD_CONTENT_PERMISSION)
 
     def testActionsInstalled(self):
@@ -255,6 +260,7 @@ class TestContentCreation(pfgtc.PloneFormGenTestCase):
 
     adapterTypes = (
         'FormSaveDataAdapter',
+        'FormSubmissionFolderAdapter',
         'FormMailerAdapter',
     )
 

--- a/Products/PloneFormGen/tests/testSubmissionFolder.py
+++ b/Products/PloneFormGen/tests/testSubmissionFolder.py
@@ -30,8 +30,8 @@ class TestCustomScript(pfgtc.PloneFormGenTestCase):
         self.form.checkAuthenticator = False
         self.form.manage_delObjects(['replyto', 'comments', 'mailer'])
         self.form.invokeFactory(
-            'FormSubmissionFolderAdapter',
-            'foo-submissions', title='Foo Submissions')
+            'FormSubmissionFolderAdapter', 'foo-submissions',
+            title='Foo Submissions', submissionTransitions=['hide'])
         self.adapter = self.form['foo-submissions']
 
         self.app.REQUEST.form['topic'] = 'Foo Submission Topic'

--- a/Products/PloneFormGen/tests/testSubmissionFolder.py
+++ b/Products/PloneFormGen/tests/testSubmissionFolder.py
@@ -1,0 +1,281 @@
+"""Tests for the Submission Folder adapter."""
+
+__author__  = 'Ross Patterson <me@rpatterson.net>'
+__docformat__ = 'plaintext'
+
+from AccessControl.SecurityManagement import getSecurityManager
+from Acquisition import aq_base
+from Testing import makerequest
+
+from Products.CMFCore.utils import getToolByName
+
+from Products.Archetypes import public
+
+from Products.PloneFormGen.tests import pfgtc
+
+
+class TestCustomScript(pfgtc.PloneFormGenTestCase):
+    """Tests for the Submission Folder adapter."""
+
+    def afterSetUp(self):
+        """Create a form folder with a submission folder adapter."""
+        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+
+        self.loginAsPortalOwner()
+        makerequest.makerequest(self.app)
+
+        self.folder.invokeFactory(
+            'FormFolder', 'foo-form-folder', title='Foo Form Folder')
+        self.form = self.folder['foo-form-folder']
+        self.form.checkAuthenticator = False
+        self.form.manage_delObjects(['replyto', 'comments', 'mailer'])
+        self.form.invokeFactory(
+            'FormSubmissionFolderAdapter',
+            'foo-submissions', title='Foo Submissions')
+        self.adapter = self.form['foo-submissions']
+
+        self.app.REQUEST.form['topic'] = 'Foo Submission Topic'
+        
+    def test_form_schema_field_methods(self):
+        """
+        Form submission schemata are extended with fields that generate methods
+        """
+        self.form.fgvalidate(self.app.REQUEST)
+        self.assertIn(
+            'foo-submission-topic', self.form['foo-submissions'],
+            'Form submission not found in the submission folder')
+        submission = self.form['foo-submissions']['foo-submission-topic']
+        schema = submission.Schema()
+        self.assertIn(
+            'title', schema, 'Form field missing from submission schema')
+        field = schema['title']
+
+        accessor = field.getAccessor(submission)
+        self.assertEqual(
+            accessor(), self.app.REQUEST.form['topic'],
+            'Wrong submission accessor value')
+
+        mutator = field.getMutator(submission)
+        mutator('Bar Submission Topic')
+        self.assertEqual(
+            submission.title, 'Bar Submission Topic',
+            'Wrong submission mutated value')
+        
+    def test_saves_submissions(self):
+        """
+        The Submission Folder adapter saves submissions.
+        """
+        self.form.fgvalidate(self.app.REQUEST)
+
+        self.assertIn(
+            'foo-submission-topic', self.form['foo-submissions'],
+            'Form submission not found in the submission folder')
+        submission = self.form['foo-submissions']['foo-submission-topic']
+        self.assertEqual(
+            submission.portal_type,
+            self.form['foo-submissions'].getSubmissionType(),
+            'Wrong form submission type')
+
+        self.logout()
+        self.assertFalse(
+            getSecurityManager().checkPermission('View', submission),
+            'New form submission is publicly visible')
+        self.loginAsPortalOwner()
+        
+        self.assertIn(
+            'title', submission.Schema(),
+            'Form field missing from submission schema')
+        foo_field_value = submission.Schema()['title'].get(submission)
+        self.assertEqual(
+            foo_field_value, self.app.REQUEST.form['topic'],
+            'Wrong submission field value')
+
+        # add another submission with the same title and id
+        self.form.fgvalidate(self.app.REQUEST)
+        self.assertIn(
+            'foo-submission-topic-1', self.form['foo-submissions'],
+            'Duplicate form submission not found in the submission folder')
+        self.form.fgvalidate(self.app.REQUEST)
+        self.assertIn(
+            'foo-submission-topic-2', self.form['foo-submissions'],
+            'Duplicate submission not found in the submission folder')
+        
+    def test_anonymous_saves_submissions(self):
+        """
+        The Submission Folder adapter saves submissions from anonymous users.
+        """
+        workflow = getToolByName(self.form, 'portal_workflow')
+        workflow.doActionFor(self.form, 'publish')
+        self.logout()
+
+        self.assertNotIn(
+            'foo-submission-topic', self.form['foo-submissions'],
+            'Form submission not found in the submission folder')
+        self.form.fgvalidate(self.app.REQUEST)
+        self.assertIn(
+            'foo-submission-topic', self.form['foo-submissions'],
+            'Form submission not found in the submission folder')
+        submission = self.form['foo-submissions']['foo-submission-topic']
+        self.assertEqual(
+            submission.getOwnerTuple(), self.adapter.getOwnerTuple(),
+            'Wrong anonymous submission owner')
+        self.assertFalse(
+            getSecurityManager().checkPermission('View', submission),
+            'Anonymous form submission is publicly visible')
+        
+    def test_other_user_saves_submissions(self):
+        """
+        The Submission Folder adapter saves submissions from other users.
+        """
+        workflow = getToolByName(self.form, 'portal_workflow')
+        workflow.doActionFor(self.form, 'publish')
+
+        membership = getToolByName(self.form, 'portal_membership')
+        membership.addMember('foo-user', 'secret', ('Member', ), ())
+        self.login('foo-user')
+
+        self.assertNotIn(
+            'foo-submission-topic', self.form['foo-submissions'],
+            'Form submission not found in the submission folder')
+        self.form.fgvalidate(self.app.REQUEST)
+        self.assertIn(
+            'foo-submission-topic', self.form['foo-submissions'],
+            'Form submission not found in the submission folder')
+        submission = self.form['foo-submissions']['foo-submission-topic']
+        self.assertEqual(
+            submission.getOwnerTuple(),
+            (list(self.portal.acl_users.getPhysicalPath()[1:]), 'foo-user'),
+            'Wrong other member submission owner')
+
+    def test_submission_title_field(self):
+        """
+        The adapter supports specifying the submission title field.
+        """
+        self.form.invokeFactory(
+            'FormStringField', 'foo-field', title='Foo Field')
+        self.adapter.update(titleField='foo-field')
+
+        self.app.REQUEST.form['foo-field'] = 'foo field value'
+        self.form.fgvalidate(self.app.REQUEST)
+
+        self.assertIn(
+            'foo-field-value', self.form['foo-submissions'],
+            'Custom title field submission not found in the submission folder')
+        self.assertNotIn(
+            'foo-submission-topic', self.form['foo-submissions'],
+            'Wrong submission title found in the submission folder')
+        submission = self.form['foo-submissions']['foo-field-value']
+
+        self.assertEqual(
+            submission.title, 'foo field value',
+            'Wrong submission field value')
+        self.assertEqual(
+            submission.topic, 'Foo Submission Topic',
+            'Wrong submission field value')
+        self.assertFalse(
+            hasattr(aq_base(submission), 'foo-field'),
+            'Wrong submission attribute')
+
+    def test_submission_type_and_folder_field(self):
+        """
+        The adapter supports specifying the submission type.
+        """
+        self.adapter.update(
+            submissionType='Event', submissionFolder=self.portal.events)
+
+        self.form.fgvalidate(self.app.REQUEST)
+
+        self.assertIn(
+            'foo-submission-topic', self.portal.events,
+            'Custom title field submission not found in the submission folder')
+        submission = self.portal.events['foo-submission-topic']
+        self.assertEqual(
+            submission.portal_type, 'Event', 'Wrong form submission type')
+
+    def test_submission_transitions_field(self):
+        """
+        Support specifying workflow transistions to apply to the submission.
+        """
+        self.adapter.update(submissionTransitions=['submit', 'publish'])
+
+        self.form.fgvalidate(self.app.REQUEST)
+
+        self.assertIn(
+            'foo-submission-topic', self.form['foo-submissions'],
+            'Custom title field submission not found in the submission folder')
+        submission = self.form['foo-submissions']['foo-submission-topic']
+
+        self.logout()
+        self.assertTrue(
+            getSecurityManager().checkPermission('View', submission),
+            'New form submission is not publicly visible')
+        self.loginAsPortalOwner()
+
+    def test_adapter_vocabs(self):
+        """
+        The vocabularies work for each of the adapter fields.
+        """
+        for field in self.adapter.Schema().fields():
+            if not isinstance(field.widget, (
+                    public.SelectionWidget, public.MultiSelectionWidget,
+                    public.PicklistWidget)):
+                # Vocab not used
+                continue
+            vocab = field.Vocabulary(self.adapter)
+            self.assertIsInstance(
+                vocab, public.DisplayList, 'Wrong field vocabulary type')
+            self.assertTrue(len(vocab), 'Wrong field vocabulary type')
+
+    def test_submission_folder_vocab(self):
+        """
+        The submission folder vocabulary includes the right types.
+        """
+        vocab, enforce = self.adapter.Vocabulary('submissionFolder')
+        self.assertIsNotNone(
+            vocab.getKey('News'), 'Missing submission folder')
+        self.assertIsInstance(
+            vocab.getKey('News'), str, 'Wrong submission folder UID type')
+        self.assertIsNotNone(
+            vocab.getKey(self.adapter.Title()),
+            'Missing adapter in folderish types')
+        self.assertIsNone(
+            vocab.getKey(self.portal['front-page'].Title()),
+            'Non-folderish item included in submission folder vocab')
+
+    def test_form_submission_types_vocab(self):
+        """
+        The form submission type vocabulary includes the right types.
+        """
+        vocab, enforce = self.adapter.Vocabulary('submissionType')
+        self.assertIsNotNone(
+            vocab.getValue('Document'), 'Missing submission type')
+        self.assertEqual(
+            vocab.getValue('Document'),
+            'Page', 'Wrong submission type title')
+        self.assertIsNone(
+            vocab.getValue('FormSubmissionFolderAdapter'),
+            'Un-addable submission type included')
+
+    def test_transitions_vocab(self):
+        """
+        The workflow transition vocabulary includes the right transitions.
+        """
+        vocab, enforce = self.adapter.Vocabulary('submissionTransitions')
+        self.assertIsNotNone(
+            vocab.getValue('submit'), 'Missing workflow transition')
+        self.assertEqual(
+            vocab.getValue('submit'),
+            'Submit for publication',
+            'Wrong workflow transition title')
+        self.assertIsNone(
+            vocab.getValue('private'),
+            'Transition included that should not be')
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    from Products.PloneTestCase.layer import ZCMLLayer
+    suite = TestSuite()
+    suite.layer = ZCMLLayer
+    suite.addTest(makeSuite(TestCustomScript))
+    return suite

--- a/Products/PloneFormGen/upgrades.zcml
+++ b/Products/PloneFormGen/upgrades.zcml
@@ -39,4 +39,19 @@
         handler=".upgrades.upgrade_to_171"
         />
 
+    <genericsetup:upgradeSteps
+        profile="Products.PloneFormGen:default"
+        source="171"
+        destination="180">
+      <genericsetup:upgradeDepends
+        title="Add Submission Folder Adapter"
+        description="Add support for the new Submission Folder Adapter type"
+        import_steps="propertiestool
+                      typeinfo
+                      workflow
+                      archetypetool
+                      factorytool"
+        />
+    </genericsetup:upgradeSteps>
+
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.7.15.dev0'
+version = '1.8.dev0'
 
 setup(name='Products.PloneFormGen',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.8.dev1'
+version = '1.8.dev2'
 
 setup(name='Products.PloneFormGen',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.8.dev.3'
+version = '1.8.dev.4'
 
 setup(name='Products.PloneFormGen',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.8.dev0'
+version = '1.8.dev1'
 
 setup(name='Products.PloneFormGen',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.8.dev2'
+version = '1.8.dev.3'
 
 setup(name='Products.PloneFormGen',
       version=version,


### PR DESCRIPTION
This supports managing submissions with folder_contents, using content rules, workflow, local roles for submissions, etc..  It could be a replacement for the saveDataAdapter expecially if we integrate or copy code from any of the add-ons that support CSV downloads of folder contents.

What are your thoughts on what it would take to get this merged?