### PR TITLE
Handle missing of gpg module. This close #106 and #109

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,8 @@ Change History
 1.7.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fixed issue that raise errors if gpg module is not found.
+  [keul] 
 
 1.7.14 (2014-01-26)
 -------------------

--- a/Products/PloneFormGen/content/formMailerAdapter.py
+++ b/Products/PloneFormGen/content/formMailerAdapter.py
@@ -752,7 +752,10 @@ class FormMailerAdapter(FormActionAdapter):
         if isinstance(body, unicode):
             body = body.encode(self.getCharset())
 
-        keyid = self.getGPGKeyId()
+        try:
+            keyid = self.getGPGKeyId()
+        except AttributeError:
+            keyid = None
         encryption = gpg and keyid
 
         if encryption:


### PR DESCRIPTION
Fixed issue described on #106 and #109: the `getGPGKeyId` is not always available.
