### PR TITLE
fix bug in save data adapter edit view 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Change History
 1.7.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- for save data adapter: handle the case in which the HTTP POST date time is added 
+  after some data had already been submitted [tkimnguyen]
 
 
 1.7.16 (2014-09-26)

--- a/Products/PloneFormGen/skins/PloneFormGen/fg_savedata_editview.pt
+++ b/Products/PloneFormGen/skins/PloneFormGen/fg_savedata_editview.pt
@@ -35,7 +35,7 @@
                             <input type="text"
                                    size="60"
                                    tal:attributes="name  string:data.item-$index:record;
-                                                   value python: data[index];
+                                                   value python: ((len(data) > index) and data[index]) or '';
                                                   "
                             />
                         </td>


### PR DESCRIPTION
If someone tells the save data adapter to include HTTP POST date and time after some data had already been submitted and saved, this would result in an error because the data list wasn't as long as expected.