### PR TITLE
fixed portal_url for captcha widget - when embedding, for example within c.cover

### DIFF
--- a/Products/PloneFormGen/skins/PloneFormGen/widget_captcha.pt
+++ b/Products/PloneFormGen/skins/PloneFormGen/widget_captcha.pt
@@ -26,7 +26,7 @@
                 tal:condition="audio_url">
                 <img src="audio_icon.gif" alt="Listen to audio for this captcha" style="cursor:pointer;"
                      tal:attributes="onclick string:playAudio('${context/@@captcha/audio_url}');
-                                     src string:${portal_url}/captcha_audio_icon.gif;" />
+                                     src string:${context/portal_url}/captcha_audio_icon.gif;" />
                 <span id="captcha-audio-embed"></span>
             </tal:block>
         </div>


### PR DESCRIPTION
<b>URL: file:/Users/peter/workspace/plone/src/Products.PloneFormGen/Products/PloneFormGen/skins/PloneFormGen/widget_captcha.pt</b><br />
<b>Line 27, Column 16</b><br />
<b>Expression: &lt;PathExpr path:u'portal_url'&gt;</b><br />
<b>Names:</b><pre>{'container': &lt;FormFolder at /test/bla&gt;,
 'context': &lt;FormFolder at /test/bla&gt;,
 'default': &lt;object object at 0x105b5ebb0&gt;,
 'here': &lt;FormFolder at /test/bla&gt;,
 'loop': {u'field': &lt;Products.PageTemplates.Expressions.PathIterator object at 0x10d20a9d0&gt;},
 'nothing': None,
 'options': {'args': (),
             'state': &lt;Products.CMFFormController.ControllerState.ControllerState object at 0x10d1b9d90&gt;},
 'repeat': &lt;Products.PageTemplates.Expressions.SafeMapping object at 0x10d1cc100&gt;,
 'request': &lt;HTTPRequest, URL=http://localhost:12280/test/cover/@@collective.cover.pfg/d66fad547bd544b78c17f84d6041604a&gt;,
 'root': &lt;Application at &gt;,
 'template': &lt;FSControllerPageTemplate at /test/bla/fg_embedded_view_p3&gt;,
 'traverse_subpath': [],
 'user': &lt;PropertiedUser 'admin'&gt;}</pre></li>

<li>  Module zope.tales.expressions, line 217, in __call__</li>

<li>  Module Products.PageTemplates.Expressions, line 147, in _eval</li>

<li>  Module zope.tales.expressions, line 118, in _eval</li>

</ul><p>KeyError: 'portal_url'
