### PR TITLE
Fix loading of widget javascripts in quickedit (#95)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Change History
 1.7.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- fixed loading of widget javascripts in quickedit (#95) [reinhardt]
 
 
 1.7.16 (2014-09-26)

--- a/Products/PloneFormGen/browser/quickedit.pt
+++ b/Products/PloneFormGen/browser/quickedit.pt
@@ -6,13 +6,14 @@
                    default_fieldset string:default;
                    fieldset default_fieldset;
                    fields python:here.fgFields(request);
+                   addable_fields view/addableFields;
                    portal_type python:here.getPortalTypeName().lower().replace(' ', '_');
                    base_macros here/fg_edit_macros_p3/macros;
                    header_macro base_macros/header;
                    typedescription_macro base_macros/typedescription;
                    footer_macro base_macros/footer;
-                   css python:here.getUniqueWidgetAttr(fields, 'helper_css');
-                   js python:here.getUniqueWidgetAttr(fields, 'helper_js');
+                   css python:here.getUniqueWidgetAttr(addable_fields, 'helper_css');
+                   js python:here.getUniqueWidgetAttr(addable_fields, 'helper_js');
                    portal portal | context/@@plone_portal_state/portal;
                    disable_column_one python:request.set('disable_plone.leftcolumn',1);
                    disable_column_two python:request.set('disable_plone.rightcolumn',1);

--- a/Products/PloneFormGen/browser/quickedit.py
+++ b/Products/PloneFormGen/browser/quickedit.py
@@ -6,6 +6,7 @@ from Products.Five import BrowserView
 from plone.memoize.view import memoize
 
 from plone.app.layout.globals.interfaces import IViewView
+from Products.CMFCore.utils import getToolByName
 from Products.PloneFormGen import PloneFormGenMessageFactory as _
 from Products.PloneFormGen import HAVE_43
 
@@ -38,6 +39,15 @@ class QuickEditView(BrowserView):
                     'description': t.Description()
                 })
         return results
+
+    def addableFields(self):
+        results = set()
+        at_tool = getToolByName(self.context, 'archetype_tool')
+        for t in self.context.allowedContentTypes():
+            if t.product == 'PloneFormGen':
+                type_spec = at_tool.lookupType(t.product, t.content_meta_type)
+                results |= set(type_spec['schema'].fields())
+        return list(results)
 
     def addablePrioritizedFields(self):
         """Return a prioritized list of the addable fields in context"""


### PR DESCRIPTION
Currently only the widget javascripts for already added objects is loaded. When adding new types the widgets are lacking their javascripts. To fix this we load the javascripts for all addable types. See issue #95 