### PR TITLE
Plone5 compatibility

### DIFF
--- a/Products/PloneFormGen/events.py
+++ b/Products/PloneFormGen/events.py
@@ -1,10 +1,10 @@
+# -*- coding: UTF-8 -*-
 from Acquisition import aq_parent, aq_inner
+from Products.ATContentTypes.interfaces import IFactoryTool
+from Products.PloneFormGen import interfaces
 from zope.component import adapter
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.lifecycleevent.interfaces import IObjectMovedEvent
-from Products.CMFPlone.interfaces import IFactoryTool
-
-from Products.PloneFormGen import interfaces
 
 
 @adapter(interfaces.IPloneFormGenActionAdapter, IObjectAddedEvent)

--- a/Products/PloneFormGen/profiles/default/metadata.xml
+++ b/Products/PloneFormGen/profiles/default/metadata.xml
@@ -2,6 +2,7 @@
 <metadata>
   <version>171</version>
   <dependencies>
+      <dependency>profile-Products.ATContentTypes:base</dependency>
       <dependency>profile-plone.app.jquerytools:default</dependency>
       <dependency>profile-collective.js.jqueryui:default</dependency>
   </dependencies>

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name='Products.PloneFormGen',
       install_requires=[
           'setuptools',
           'Products.Archetypes>=1.7.14',  # placeholder support
+          'Products.ATContentTypes>=2.2.3',  # 'base'-profile
           'Products.CMFPlone',
           'Products.TALESField>=1.1.3',
           'Products.TemplateFields>=1.2.4',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(name='Products.PloneFormGen',
       install_requires=[
           'setuptools',
           'Products.Archetypes>=1.7.14',  # placeholder support
-          'Products.ATContentTypes>=2.2.3',  # 'base'-profile
           'Products.CMFPlone',
           'Products.TALESField>=1.1.3',
           'Products.TemplateFields>=1.2.4',


### PR DESCRIPTION
Products.ATContentTypes now has a base-profile that allows PFG to depend on atct without removing the default types in Plone5.