### PR TITLE
Removed placeholder from fields with no use for it.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Change History
 -------------------
 
 - fixed loading of widget javascripts in quickedit (#95) [reinhardt]
+- left placeholder only for fields where it makes sense [montypie]
 
 
 1.7.16 (2014-09-26)

--- a/Products/PloneFormGen/content/fields.py
+++ b/Products/PloneFormGen/content/fields.py
@@ -118,10 +118,10 @@ class FGPasswordField(FGStringField):
         sizeField,
     ))
 
-    # 'hidden' isn't really useful for this field.
+    # attributes that are not really useful for Password field.
     del schema['hidden']
-    # 'serverSide' is not really useful for this field.
     del schema['serverSide']
+    del schema['placeholder']
 
     # hide references & discussion
     finalizeFieldSchema(schema, folderish=True, moveDiscussion=False)
@@ -364,10 +364,10 @@ class FGBooleanField(BaseFormField):
            particular input, choose a validator below.
         """)
 
-    # 'hidden' isn't really useful for this field.
+    # attributes that are not really useful for Boolean field.
     del schema['hidden']
-    # 'serverSide' is not really useful for this field.
     del schema['serverSide']
+    del schema['placeholder']
 
     # hide references & discussion
     finalizeFieldSchema(schema, folderish=True, moveDiscussion=False)
@@ -482,10 +482,10 @@ class FGDateField(BaseFormField):
         ),
 ))
 
-    # 'hidden' isn't really useful for this field.
+    # attributes that are not really useful for Date/Time field.
     del schema['hidden']
-    # 'serverSide' is not really useful for this field.
     del schema['serverSide']
+    del schema['placeholder']
 
     # hide references & discussion
     finalizeFieldSchema(schema, folderish=True, moveDiscussion=False)
@@ -548,8 +548,8 @@ class FGDateField(BaseFormField):
             except ValueError:
                 pass
         else:
-                self.fgField.widget.ending_year = None
-                self.fgEndingYear = value
+            self.fgField.widget.ending_year = None
+            self.fgEndingYear = value
 
 
     security.declareProtected(ModifyPortalContent, 'setFgFutureYears')
@@ -710,11 +710,11 @@ class FGSelectionField(BaseFormField):
         ),
     ))
 
-    # 'hidden' isn't really useful for a selection field.
+    # attributes that are not really useful for a selection field.
     # Just use a hidden string field if you really need this.
     del schema['hidden']
-    # 'serverSide' is not really useful for this field.
     del schema['serverSide']
+    del schema['placeholder']
 
     # hide references & discussion
     finalizeFieldSchema(schema, folderish=True, moveDiscussion=False)
@@ -810,8 +810,8 @@ class FGMultiSelectField(BaseFormField):
     # current Archetypes doesn't really support hidden for
     # multi-select. Use a lines field if you really need this
     del schema['hidden']
-    # 'serverSide' is not really useful for this field.
     del schema['serverSide']
+    del schema['placeholder']
 
     # hide references & discussion
     finalizeFieldSchema(schema, folderish=True, moveDiscussion=False)
@@ -1012,11 +1012,11 @@ class FGRichTextField(BaseFormField):
 
     schema = BaseFieldSchemaRichTextDefault.copy()
 
-    # 'hidden' isn't really useful for an RT field.
+    # attributes that are not really useful for an RT field.
     # Just use a hidden string field if you really need this.
     del schema['hidden']
-    # 'serverSide' is not really useful for this field.
     del schema['serverSide']
+    del schema['placeholder']
 
     if HAS_MX_TIDY:
         schema = schema + Schema((
@@ -1200,10 +1200,10 @@ class FGFileField(BaseFormField):
 
     ))
 
-    # 'hidden' isn't really useful for a file field.
+    # attributes that are not really useful for a file field.
     del schema['hidden']
-    # 'serverSide' is not really useful for this field.
     del schema['serverSide']
+    del schema['placeholder']
 
     finalizeFieldSchema(schema, folderish=True, moveDiscussion=False)
 
@@ -1286,6 +1286,7 @@ class FGCaptchaField(FGStringField):
     # some attributes that don't make sense for a CAPTCHA field
     del schema['required']
     del schema['hidden']
+    del schema['placeholder']
     noview = {'view': 'invisible', 'edit': 'invisible'}
     schema['fgDefault'].widget.visible = noview
     schema['fgTDefault'].widget.visible = noview
@@ -1320,6 +1321,7 @@ class FGFieldsetStart(BaseFormField):
 
     schema =  BaseFieldSchema.copy()
     del schema['hidden']
+    del schema['placeholder']
     noview = {'view': 'invisible', 'edit': 'invisible'}
     schema['fgTEnabled'].widget.visible = noview
     schema['fgTDefault'].widget.visible = noview
@@ -1387,6 +1389,7 @@ class FGFieldsetEnd(BaseFormField):
     _at_rename_after_creation = False
 
     del schema['hidden']
+    del schema['placeholder']
     noview = {'view': 'invisible', 'edit': 'invisible'}
     schema['fgTEnabled'].widget.visible = noview
     schema['fgTDefault'].widget.visible = noview
@@ -1423,4 +1426,3 @@ class FGFieldsetEnd(BaseFormField):
         return True
 
 registerType(FGFieldsetEnd, PROJECTNAME)
-


### PR DESCRIPTION
This is an aftermath of #120, which unintentionally put placeholders on all fields, not just text input fields.