### PR TITLE
Plone 5 fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python: 2.7
 env:
   - PLONE_VERSION=4.2
   - PLONE_VERSION=4.3
-  - PLONE_VERSION=5.0
+  - PLONE_VERSION=5
 matrix:
   include:
     - python: 2.6
@@ -11,7 +11,7 @@ matrix:
   allow_failures:
     - python: 2.6
       env: PLONE_VERSION=4.1
-    - env: PLONE_VERSION=5.0
+    - env: PLONE_VERSION=5
   fast_finish: true
 install:
   - sed -ie "s#travis-4.x.cfg#travis-$PLONE_VERSION.x.cfg#" travis.cfg

--- a/Products/PloneFormGen/browser/embedded.py
+++ b/Products/PloneFormGen/browser/embedded.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_inner
 from Products.Five import BrowserView
+from Products.statusmessages.interfaces import IStatusMessage
 
 DEFAULT_SUBMISSION_MARKER = 'form.submitted'
 
@@ -84,13 +85,16 @@ class EmbeddedPFGView(BrowserView):
         else:
             self.request.set('pfg_form_action', self.request['URL'])
 
+        self.status = IStatusMessage(self.request)
+        self.request.set('messages', self.status.show())
         # Delegate to CMFFormController page template so we can share logic with the standalone form
         try:
             context = aq_inner(self.context)
+            self.request.view = self
             return context.fg_embedded_view_p3(
                 enable_unload_protection=self.enable_unload_protection,
                 enable_auto_focus=self.enable_auto_focus
-                )
+            )
         finally:
             # Clean up
             if fiddled_submission_marker is not None:
@@ -99,6 +103,9 @@ class EmbeddedPFGView(BrowserView):
                 del self.request.form['form.submitted']
             if fiddled_controller_state is not None:
                 self.request.set('controller_state', fiddled_controller_state)
-            del self.request.form['pfg_form_marker']
-            del self.request.other['pfg_form_action']
-            del self.request.other['pfg_form_submitted']
+            try:
+                del self.request.other['pfg_form_action']
+                del self.request.other['pfg_form_submitted']
+                del self.request.form['pfg_form_marker']
+            except KeyError:
+                pass

--- a/Products/PloneFormGen/browser/resources/quickedit.js
+++ b/Products/PloneFormGen/browser/resources/quickedit.js
@@ -106,7 +106,10 @@ jQuery(function ($) {
 
 	// set up edit and delete popups
 	if ($.fn.prepOverlay) {
-		$('.editHook a[href$=edit]').prepOverlay({
+		var edit_url = $('.editHook a[href$=edit]').attr('href');
+		$('.editHook a[href$=edit]').attr('href',
+			edit_url + '?_authenticator=' + getToken());
+		$('.editHook a[href*="/edit"]').prepOverlay({
 			subtype: 'ajax',
 			filter: "#content",
 			formselector: 'form[name=edit_form]:not(.fgBaseEditForm)',
@@ -135,7 +138,7 @@ jQuery(function ($) {
 				}
 				return 'close';
 			},
-			closeselector: '[name="form.button.Cancel"]'
+			closeselector: '[name="form.button.Cancel"], [name="form.buttons.Cancel"]'
 		});
 	}
 
@@ -286,7 +289,7 @@ jQuery(function ($) {
 			node.setAttribute("type", "text");
 
 			// then we attach a new event to label fields
-			$("#pfg-qetable .qefield label.formQuestion").live('dblclick', function (e) {
+			$("#pfg-qetable").on('dblclick', ".qefield label.formQuestion", function (e) {
 				var content, tmpfor, jqt;
 
 				jqt = $(this);
@@ -340,7 +343,7 @@ jQuery(function ($) {
 				}
 			});
 
-			$("span.not-required").live("click", function (event) {
+			$(document).on("click", "span.not-required", function (event) {
 				var item, jqt;
 
 				jqt = $(this);
@@ -360,7 +363,7 @@ jQuery(function ($) {
 				jqt.attr("title", "Remove required flag?");
 			});
 
-			$("span.required").live("click", function (event) {
+			$(document).on("click", "span.required", function (event) {
 				var item, jqt;
 
 				jqt = $(this);
@@ -406,11 +409,11 @@ jQuery(function ($) {
 		},
 
 		deinit: function () {
-			$("label.formQuestion").die(); // removes event handlers setup by .live
+			$("#pfg-qetable").off('click dblclick', ".qefield label.formQuestion"); // removes event handlers setup by .live
 			$(".more").remove();		// remove the item with bounded events to avoid conflict when "quick-edit mode" is called again
-			$("span.not-required").die();
+			$(document).off("click", "span.not-required");
 			$("span.not-required").remove(); // we don't want blank square showed in the form
-			$("span.required").die(); // remove live() event listener
+			$(document).off("click", "span.required"); // remove live() event listener
 			// hide all the error messages so far!
 			if ($("div.error").length > 0) {
 				$("div.error").hide();
@@ -451,11 +454,12 @@ jQuery(function ($) {
 						item.before("<div class='draggable draggingHook editHook qechild'>⣿</div>");
 						$("img.ajax-loader").css('visibility', 'visible');
 						item.width($(item).width());
+						var create_url = "createObject?type_name=" + ui.item.context.id;
+						create_url += '&_authenticator=' + getToken();
 						//	$(item).height($(item).height());
 						// AJAX stuff
 						item.children("div.widget-inside")
-                        .load("createObject?type_name=" +
-                              ui.item.context.id + " #content > div:last",
+                        .load(create_url + " #content > div:last",
                                function (response, status, xhr) {
 							var inputElem, formElem, msg, jqt;
 
@@ -527,7 +531,7 @@ jQuery(function ($) {
 						// current position in the table
 						currpos = $(".item_" + i).parent().index();
 
-						$("#pfg-qetable [name='form.button.save'], #pfgActionEdit [name='form.button.save']").live('click', function (e) {
+						$("#pfg-qetable, #pfgActionEdit").on('click', "[name='form.button.save']", function (e) {
 							var button = $(this),
                                 formParent = $(this).closest('form'),
                                 formAction = formParent.attr('action'),
@@ -577,7 +581,7 @@ jQuery(function ($) {
 							return false;
 						});
 
-						$("#pfg-qetable [name='form.button.cancel'], #pfgActionEdit [name='form.button.cancel']").live('click', function (e) {
+						$("#pfg-qetable, #pfgActionEdit").on('click', "[name='form.button.cancel']", function (e) {
 							var widgetParent;
 
 							e.preventDefault();

--- a/Products/PloneFormGen/events.py
+++ b/Products/PloneFormGen/events.py
@@ -2,7 +2,10 @@ from Acquisition import aq_parent, aq_inner
 from zope.component import adapter
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.lifecycleevent.interfaces import IObjectMovedEvent
-from Products.CMFPlone.interfaces import IFactoryTool
+try:
+    from Products.CMFPlone.interfaces import IFactoryTool
+except ImportError:
+    from Products.ATContentTypes.interfaces import IFactoryTool
 
 from Products.PloneFormGen import interfaces
 

--- a/Products/PloneFormGen/skins/PloneFormGen/fg_embedded_view_p3.cpt
+++ b/Products/PloneFormGen/skins/PloneFormGen/fg_embedded_view_p3.cpt
@@ -1,7 +1,20 @@
 <metal:block use-macro="here/global_defines/macros/defines" />
 <div class="pfg-embedded">
     <tal:block tal:condition="python:request.other.get('pfg_form_submitted', False)">
-        <tal:block metal:use-macro="context/global_statusmessage/macros/portal_message"/>
+
+    <tal:statusmsg tal:define="messages request/messages|python:[]"
+                   tal:repeat="message messages">
+        <div tal:define="mtype message/type | nothing;"
+             tal:attributes="class string:portalMessage ${mtype};">
+            <strong
+                i18n:translate="" tal:content="python:mtype.capitalize()">Info</strong>
+            <span class="content"
+                  tal:replace="message/message | nothing" i18n:translate="">
+                The status message.
+            </span>
+        </div>
+    </tal:statusmsg>
+
     </tal:block>
     <tal:block
         tal:define="errors options/state/getErrors | nothing;

--- a/Products/PloneFormGen/tests/attachment.txt
+++ b/Products/PloneFormGen/tests/attachment.txt
@@ -1,17 +1,40 @@
 File attachments
 ================
 
+    >>> app = layer['app']
+    >>> portal = layer['portal']
+    >>> from Products.PloneFormGen.tests.pfgtc import MailHostMock
+    >>> portal.MailHost = MailHostMock()
+    >>> portal_url = portal.portal_url()
+    >>> request = layer['request']
     >>> import cStringIO
-    >>> browser = self.browser
+    >>> from plone.testing.z2 import Browser
+    >>> browser = Browser(app)
+
+Login to the portal:
+
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import login
+    >>> from plone.app.testing import TEST_USER_NAME
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> setRoles(portal, TEST_USER_ID, ['Manager'])
+    >>> login(portal, TEST_USER_NAME)
+    >>> import transaction
+    >>> transaction.commit()
+    >>> browser.open(portal_url + '/login_form')
+    >>> browser.getControl(name='__ac_name').value = TEST_USER_NAME
+    >>> browser.getControl(name='__ac_password').value = TEST_USER_PASSWORD
+    >>> browser.getControl(name='submit').click()
 
 Add a new Form Folder::
 
-    >>> browser.open(self.portal_url)
+    >>> browser.open(portal_url)
     >>> browser.getLink('Form Folder').click()
     >>> browser.getControl('Title').value = 'attachmentform'
     >>> browser.getControl('Save').click()
     >>> browser.url
-    'http://nohost/plone/attachmentform/...'
+    '.../attachmentform/...'
 
 Add a File field::
 
@@ -21,9 +44,9 @@ Add a File field::
 
 And confirm that it renders properly::
     
-    >>> browser.open(self.portal_url + '/attachmentform')
+    >>> browser.open(portal_url + '/attachmentform')
     >>> browser.url
-    'http://nohost/plone/attachmentform...'
+    '.../attachmentform...'
     >>> print browser.contents
     <!DOCTYPE...
     ...
@@ -32,7 +55,9 @@ And confirm that it renders properly::
 
 Submit the form with an attachment::
 
-    >>> self.portal.attachmentform.mailer.setRecipient_email('mdummy@address.com')
+    >>> portal.attachmentform.mailer.setRecipient_email('mdummy@address.com')
+    >>> import transaction
+    >>> transaction.commit()
     >>> browser.getControl('Your E-Mail Address').value = 'test@example.com'
     >>> browser.getControl('Subject').value = 'test'
     >>> browser.getControl('Comments').value = 'PFG rocks!'
@@ -44,8 +69,8 @@ Submit the form with an attachment::
 
 Make sure the attachment was included in the email message::
 
-
-    >>> self.portal.MailHost.msg.get_payload()[1].get_payload(decode=True)
+    >>> app._p_jar.sync()
+    >>> portal.MailHost.msg.get_payload()[1].get_payload(decode=True)
     'file contents'
 
 Excluded fields
@@ -54,15 +79,18 @@ Excluded fields
 Make sure the attachment is not included in the email if showAll is False and
 the file field is not listed in the mailer's showFields::
 
-    >>> self.portal.attachmentform.mailer.setShowAll(False)
-    >>> self.portal.MailHost.msg = None
+    >>> portal.attachmentform.mailer.setShowAll(False)
+    >>> portal.MailHost.msg = None
+    >>> transaction.commit()
     
-    >>> browser.open('http://nohost/plone/attachmentform')
+    >>> browser.open(portal_url + '/attachmentform')
     >>> browser.getControl('Your E-Mail Address').value = 'test@example.com'
     >>> browser.getControl('Subject').value = 'test'
     >>> browser.getControl('Comments').value = 'PFG rocks!'
     >>> browser.getControl(name='attachment_file').add_file(cStringIO.StringIO('file contents'), 'text/plain', 'test.txt')
     >>> browser.getControl('Submit').click()
     <sent mail from ...to ['mdummy@address.com']>
-    >>> self.portal.MailHost.msg.get_payload(decode=True)
-    '<html xmlns="http://www.w3.org/1999/xhtml">\n\n  <head><title></title></head>\n\n  <body>\n    <p></p>\n    <dl>\n    </dl>\n    <p></p>\n    <pre></pre>\n  </body>\n</html>\n'
+
+    >>> app._p_jar.sync()
+    >>> 'file contents' not in portal.MailHost.msg.get_payload(decode=True)
+    True

--- a/Products/PloneFormGen/tests/browser.txt
+++ b/Products/PloneFormGen/tests/browser.txt
@@ -1,14 +1,38 @@
 Integration tests
 =================
 
-    >>> browser = self.browser
+    >>> app = layer['app']
+    >>> portal = layer['portal']
+    >>> from Products.PloneFormGen.tests.pfgtc import MailHostMock
+    >>> portal.MailHost = MailHostMock()
+    >>> portal_url = portal.portal_url()
+    >>> request = layer['request']
+    >>> from plone.testing.z2 import Browser
+    >>> browser = Browser(app)
+
+Login to the portal:
+
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import login
+    >>> from plone.app.testing import TEST_USER_NAME
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> setRoles(portal, TEST_USER_ID, ['Manager'])
+    >>> login(portal, TEST_USER_NAME)
+    >>> import transaction
+    >>> transaction.commit()
+    >>> browser.open(portal_url + '/login_form')
+    >>> browser.getControl(name='__ac_name').value = TEST_USER_NAME
+    >>> browser.getControl(name='__ac_password').value = TEST_USER_PASSWORD
+    >>> browser.getControl(name='submit').click()
+
 
 Standalone form
 ---------------
 
 Add a new Form Folder::
 
-    >>> browser.open(self.portal_url)
+    >>> browser.open(portal_url)
     >>> browser.getLink('Form Folder').click()
     >>> browser.getControl('Title').value = 'testform'
     >>> browser.getControl('Save').click()
@@ -16,24 +40,24 @@ Add a new Form Folder::
 We'll want to test the save data adapter later.
 Let's add one now::
 
-    >>> browser.open(self.portal_url + '/testform')
+    >>> browser.open(portal_url + '/testform')
     >>> browser.getLink('Save Data Adapter').click()
     >>> browser.getControl('Title').value = 'saver'
     >>> browser.getControl('Save').click()
-    >>> browser.open(self.portal_url + '/testform/saver')
+    >>> browser.open(portal_url + '/testform/saver')
     >>> browser.url
-    'http://nohost/plone/testform/saver'
+    '.../testform/saver'
 
 Return to form and confirm that it renders properly::
 
-    >>> browser.open(self.portal_url + '/testform')
+    >>> browser.open(portal_url + '/testform')
     >>> browser.url
-    'http://nohost/plone/testform'
+    '.../testform'
     >>> print browser.contents
     <!DOCTYPE...
     ...
      <div class="pfg-form formid-testform">
-      <form ...action="http://nohost/plone/testform"...>
+      <form ...action=".../testform"...>
           ...
           <input...name="replyto".../>
           ...
@@ -55,12 +79,13 @@ Return to form and confirm that it renders properly::
 
 Submit the form.  An incomplete submission should give validation errors::
 
-    >>> self.portal.testform.mailer.setRecipient_email('mdummy@address.com')
+    >>> portal.testform.mailer.setRecipient_email('mdummy@address.com')
+    >>> transaction.commit()
     >>> browser.getControl('Your E-Mail Address').value = 'test@example.com'
     >>> browser.getControl('Subject').value = 'test'
     >>> browser.getControl('Submit').click()
     >>> browser.url
-    'http://nohost/plone/testform'
+    '.../testform'
     >>> 'Please correct the indicated errors.' in browser.contents
     True
 
@@ -73,15 +98,15 @@ base class)::
     >>> browser.getControl('Submit').click()
     <sent mail from ...to ['mdummy@address.com']>
     >>> browser.url
-    'http://nohost/plone/testform'
+    '.../plone/testform'
     >>> 'Thanks for your input.' in browser.contents
     True
 
 We should be able to view an individual field::
 
-    >>> browser.open(self.portal_url + '/testform/comments')
+    >>> browser.open(portal_url + '/testform/comments')
     >>> browser.url
-    'http://nohost/plone/testform/comments'
+    '.../plone/testform/comments'
 
     >>> print browser.contents
     <!DOCTYPE...
@@ -104,16 +129,16 @@ We should be able to view an individual field::
 
 Let's take a look at the save-data adapter::
 
-    >>> browser.open(self.portal_url + '/testform/saver')
+    >>> browser.open(portal_url + '/testform/saver')
     >>> browser.url
-    'http://nohost/plone/testform/saver'
+    '.../plone/testform/saver'
 
 It ought to tell us we have a saved input::
 
     >>> print browser.contents
     <!DOCTYPE...
     ...
-    <span>1</span> input(s) saved
+    ...<span>1</span> input(s) saved...
     ...
 
 And a form offering to clear input::
@@ -121,12 +146,10 @@ And a form offering to clear input::
     >>> print browser.contents
     <!DOCTYPE...
     ...
-    <form action="http://nohost/plone/testform/saver/clearSavedFormInput" method="post"...>
-        <input type="hidden" name="_authenticator" value="..."/>
-        <input type="submit" ... value="Clear Saved Input" ... />
-          ...
-              Clear all saved input?
-          ...
+    <form action=".../testform/saver/clearSavedFormInput" method="post"...>
+        <input type="hidden" name="_authenticator" value="...
+        <input type="submit" ... value="Clear Saved Input" ...
+          ...Clear all saved input?...
     </form>
     ...
 
@@ -134,11 +157,11 @@ And a form offering to clear input::
 
     >>> browser.getControl('Clear Saved Input').click()
     >>> browser.url
-    'http://nohost/plone/testform/saver'
+    '.../testform/saver'
 
 Attempts to use clearSavedFormInput without auth should be forbidden::
 
-    >>> browser.open(self.portal_url + '/testform/saver/clearSavedFormInput')
+    >>> browser.open(portal_url + '/testform/saver/clearSavedFormInput')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 403: Forbidden
@@ -146,91 +169,91 @@ Attempts to use clearSavedFormInput without auth should be forbidden::
 
 Attempts to use gpg_services TTW should be fruitless::
 
-    >>> browser.open(self.portal_url + '/testform/@@gpg_services/encrypt?data=XXX&recipient_key_id=yyy')
+    >>> browser.open(portal_url + '/testform/@@gpg_services/encrypt?data=XXX&recipient_key_id=yyy')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
 Attempts to read the success action TTW should be fruitless::
 
-    >>> browser.open(self.portal_url + '/testform/fgGetSuccessAction')
+    >>> browser.open(portal_url + '/testform/fgGetSuccessAction')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
 That should also be true for fields::
 
-    >>> browser.open(self.portal_url + '/testform/comments/fgGetSuccessAction')
+    >>> browser.open(portal_url + '/testform/comments/fgGetSuccessAction')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
 Attempts to set mailer body TTW should fail
-    >>> browser.open(self.portal_url + '/testform/mailer/setBody_pt?value=stuff')
+    >>> browser.open(portal_url + '/testform/mailer/setBody_pt?value=stuff')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
 Attempts to read mailer body TTW should fail
-    >>> browser.open(self.portal_url + '/testform/mailer/body_pt')
+    >>> browser.open(portal_url + '/testform/mailer/body_pt')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
 We want to test security on the custom script adapter. Let's add one::
 
-    >>> browser.open(self.portal_url + '/testform')
+    >>> browser.open(portal_url + '/testform')
     >>> browser.getLink('Custom Script Adapter').click()
     >>> browser.getControl('Title').value = 'Test Script Adapter'
     >>> browser.getControl('Save').click()
-    >>> browser.open(self.portal_url + '/testform/test-script-adapter')
+    >>> browser.open(portal_url + '/testform/test-script-adapter')
     >>> browser.url
-    'http://nohost/plone/testform/test-script-adapter'
+    '.../testform/test-script-adapter'
 
 Attempts to set script body TTW should fail::
 
-    >>> browser.open(self.portal_url + '/testform/test-script-adapter/updateScript?body=raise%2010&role=none')
+    >>> browser.open(portal_url + '/testform/test-script-adapter/updateScript?body=raise%2010&role=none')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
 Attempts to run the script TTW should fail::
 
-    >>> browser.open(self.portal_url + '/testform/test-script-adapter/onSuccess?fields=')
+    >>> browser.open(portal_url + '/testform/test-script-adapter/onSuccess?fields=')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
-    >>> browser.open(self.portal_url + '/testform/test-script-adapter/scriptBody?fields=')
+    >>> browser.open(portal_url + '/testform/test-script-adapter/scriptBody?fields=')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
-    >>> browser.open(self.portal_url + '/testform/test-script-adapter/executeCustomScript?fields=&form=&req=')
+    >>> browser.open(portal_url + '/testform/test-script-adapter/executeCustomScript?fields=&form=&req=')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
 Attempts to use onSuccess TTW should fail::
 
-    >>> browser.open(self.portal_url + '/testform/saver/onSuccess?fields=&request=')
+    >>> browser.open(portal_url + '/testform/saver/onSuccess?fields=&request=')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
 Attempts to read our special member attributes TTW should fail::
 
-    >>> browser.open(self.portal_url + '/testform/memberId')
+    >>> browser.open(portal_url + '/testform/memberId')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
-    >>> browser.open(self.portal_url + '/testform/memberFullName')
+    >>> browser.open(portal_url + '/testform/memberFullName')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
 
-    >>> browser.open(self.portal_url + '/testform/memberEmail')
+    >>> browser.open(portal_url + '/testform/memberEmail')
     Traceback (most recent call last):
     ...
     HTTPError: HTTP Error 404: Not Found
@@ -249,7 +272,7 @@ Attempts to read our special member attributes TTW should fail::
 #
 # Now we should be able to render the same form as above, but located at @@form-wrapper::
 #
-#     >>> browser.open(self.portal_url + '/@@form-wrapper')
+#     >>> browser.open(portal_url + '/@@form-wrapper')
 #     >>> print browser.contents
 #     <!DOCTYPE...
 #     ...

--- a/Products/PloneFormGen/tests/pfgtc.py
+++ b/Products/PloneFormGen/tests/pfgtc.py
@@ -1,14 +1,16 @@
 
 import email
+import unittest
 
 # Import the base test case classes
-from Testing import ZopeTestCase
-from Products.CMFPlone.tests import PloneTestCase
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import IntegrationTesting
+from plone.app.testing.bbb import PTC_FIXTURE, PloneTestCase
+from plone.app.testing import PloneSandboxLayer
+from plone.testing import z2
 
-from Products.Five import fiveconfigure
-from Products.Five import zcml
-from Products.PloneTestCase.layer import onsetup
 import Products.PloneFormGen
+import plone.app.layout
 try:
     import collective.recaptcha
     haveRecaptcha = True
@@ -17,56 +19,57 @@ except ImportError:
     print "collective.recaptcha is unavailable: captcha tests will be skipped."
 
 from Products.Five.testbrowser import Browser
+from Products.MailHost.MailHost import MailHost
 
-ZopeTestCase.installProduct('PloneFormGen')
-
-@onsetup
-def setup_product():
-    fiveconfigure.debug_mode = True
-    zcml.load_config('configure.zcml', Products.PloneFormGen)
-    if haveRecaptcha:
-        zcml.load_config('configure.zcml', collective.recaptcha)
-    fiveconfigure.debug_mode = False
-
-# Set up the Plone site used for the test fixture. The PRODUCTS are the products
-# to install in the Plone site (as opposed to the products defined above, which
-# are all products available to Zope in the test fixture)
-setup_product()
-PloneTestCase.setupPloneSite(products=['PloneFormGen'])
 
 class Session(dict):
     def set(self, key, value):
         self[key] = value
 
-from Products.MailHost.MailHost import MailHost
+
 class MailHostMock(MailHost):
     def _send(self, mfrom, mto, messageText, immediate=False):
         print '<sent mail from %s to %s>' % (mfrom, mto)
         self.msgtext = messageText
         self.msg = email.message_from_string(messageText.lstrip())
 
-class PloneFormGenTestCase(PloneTestCase.PloneTestCase):
-    def _setup(self):
-        # make sure we test in Plone 2.5 with the exception hook monkeypatch applied
+
+class Fixture(PloneSandboxLayer):
+
+    defaultBases = (PTC_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        self.loadZCML(package=Products.PloneFormGen)
+        self.loadZCML(package=plone.app.layout)
+        if haveRecaptcha:
+            self.loadZCML(package=collective.recaptcha)
+        z2.installProduct(app, 'Products.PloneFormGen')
+
+    def setUpPloneSite(self, portal):
+        # Install into Plone site using portal_setup
+        self.applyProfile(portal, 'Products.PloneFormGen:default')
+
+
+FIXTURE = Fixture()
+
+PFG_INTEGRATION_TESTING = IntegrationTesting(
+    bases=(FIXTURE,),
+    name='Products.PloneFormGen:Integration',
+)
+PFG_FUNCTIONAL_TESTING = FunctionalTesting(
+    bases=(FIXTURE, z2.ZSERVER_FIXTURE),
+    name='Products.PloneFormGen:Functional',
+)
+
+
+class PloneFormGenTestCase(PloneTestCase):
+
+    layer = PFG_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.app = self.layer['app']
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
         Products.PloneFormGen.config.PLONE_25_PUBLISHER_MONKEYPATCH = True
-
-        PloneTestCase.PloneTestCase._setup(self)
-        self.app.REQUEST['SESSION'] = Session()
-
-class PloneFormGenFunctionalTestCase(PloneTestCase.FunctionalTestCase):
-
-    def _setup(self):
-        PloneTestCase.FunctionalTestCase._setup(self)
-        self.app.REQUEST['SESSION'] = Session()
-        self.browser = Browser()
-        self.app.acl_users.userFolderAddUser('root', 'secret', ['Manager'], [])
-        self.browser.addHeader('Authorization', 'Basic root:secret')
-        self.portal_url = 'http://nohost/plone'
-
-    def afterSetUp(self):
-        super(PloneTestCase.FunctionalTestCase, self).afterSetUp()
-        self.portal.MailHost = MailHostMock()
-
-    def setStatusCode(self, key, value):
-        from ZPublisher import HTTPResponse
-        HTTPResponse.status_codes[key.lower()] = value
+        self.request.set('SESSION', Session())
+        super(PloneFormGenTestCase, self).setUp()

--- a/Products/PloneFormGen/tests/pfgtc.py
+++ b/Products/PloneFormGen/tests/pfgtc.py
@@ -1,12 +1,13 @@
 
 import email
-import unittest
 
 # Import the base test case classes
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing.bbb import PTC_FIXTURE, PloneTestCase
 from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
 from plone.testing import z2
 
 import Products.PloneFormGen
@@ -73,3 +74,8 @@ class PloneFormGenTestCase(PloneTestCase):
         Products.PloneFormGen.config.PLONE_25_PUBLISHER_MONKEYPATCH = True
         self.request.set('SESSION', Session())
         super(PloneFormGenTestCase, self).setUp()
+        if getattr(self, 'folder', None) is None:
+            setRoles(self.portal, TEST_USER_ID, ['Manager'])
+            self.portal.invokeFactory('Folder', 'test-folder')
+            setRoles(self.portal, TEST_USER_ID, ['Member'])
+            self.folder = self.portal['test-folder']

--- a/Products/PloneFormGen/tests/profiles/testing/structure/.objects
+++ b/Products/PloneFormGen/tests/profiles/testing/structure/.objects
@@ -1,1 +1,1 @@
-Members,Large Plone Folder
+Members,Folder

--- a/Products/PloneFormGen/tests/profiles/testing/structure/Members/.properties
+++ b/Products/PloneFormGen/tests/profiles/testing/structure/Members/.properties
@@ -1,0 +1,3 @@
+[DEFAULT]
+title: Members
+description: Members Folder

--- a/Products/PloneFormGen/tests/profiles/testing/structure/Members/test_user_1_/.properties
+++ b/Products/PloneFormGen/tests/profiles/testing/structure/Members/test_user_1_/.properties
@@ -1,0 +1,3 @@
+[DEFAULT]
+title: Test User 1
+description: User Folder

--- a/Products/PloneFormGen/tests/serverside_field.txt
+++ b/Products/PloneFormGen/tests/serverside_field.txt
@@ -2,24 +2,42 @@ Server-side only field
 ----------------------
 
 Get our test browser::
-
-    >>> from Products.Five.testbrowser import Browser
-    >>> browser = Browser()
-    >>> portal_url = 'http://nohost/plone'
-    >>> self.app.acl_users.userFolderAddUser('root', 'secret', ['Manager'], [])
-    >>> browser.addHeader('Authorization', 'Basic root:secret')
+    
+    >>> app = layer['app']
+    >>> portal = layer['portal']
+    >>> from Products.PloneFormGen.tests.pfgtc import MailHostMock
+    >>> portal.MailHost = MailHostMock()
+    >>> portal_url = portal.portal_url()
+    >>> request = layer['request']
+    >>> from plone.testing.z2 import Browser
+    >>> browser = Browser(app)
 
 Add a new form folder and mark the subject input variable as a server side variable.
 (It needs a non-empty default value because it's set as required.) ::
   
-    >>> self.setRoles(['Manager'])
-    >>> self.portal.invokeFactory('FormFolder', 'testform')
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import login
+    >>> from plone.app.testing import TEST_USER_NAME
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> setRoles(portal, TEST_USER_ID, ['Manager'])
+    >>> login(portal, TEST_USER_NAME)
+    >>> portal.invokeFactory('FormFolder', 'testform')
     'testform'
-    >>> self.portal.testform.topic.setServerSide(True)
-    >>> self.portal.testform.topic.getServerSide()
+    >>> portal.testform.topic.setServerSide(True)
+    >>> portal.testform.topic.getServerSide()
     True
 
-    >>> self.portal.testform.topic.setFgDefault('asdf')
+    >>> portal.testform.topic.setFgDefault('asdf')
+    >>> import transaction
+    >>> transaction.commit()
+
+Login to the portal:
+
+    >>> browser.open(portal_url + '/login_form')
+    >>> browser.getControl(name='__ac_name').value = TEST_USER_NAME
+    >>> browser.getControl(name='__ac_password').value = TEST_USER_PASSWORD
+    >>> browser.getControl(name='submit').click()
 
 And confirm that the server-side field is absent from the rendered form::
     
@@ -30,7 +48,8 @@ And confirm that the server-side field is absent from the rendered form::
 By default when we submit the form the server-side field won't be included on the
 thank you page::
 
-    >>> self.portal.testform.mailer.setRecipient_email('mdummy@address.com')
+    >>> portal.testform.mailer.setRecipient_email('mdummy@address.com')
+    >>> transaction.commit()
     >>> browser.getControl('Your E-Mail Address').value = 'test@example.com'
     >>> browser.getControl('Comments').value = 'Now with double the rockage...'
     >>> browser.getControl('Submit').click()
@@ -41,25 +60,28 @@ thank you page::
 
 Test for 'Subject' in the mail body::
 
-    >>> msgtext = self.portal.MailHost.msgtext[self.portal.MailHost.msgtext.index('\n\n'):]
-    >>> body = '\n\n'.join(self.portal.MailHost.msgtext.split('\n\n')[1:])
+    >>> app._p_jar.sync()
+    >>> msgtext = portal.MailHost.msgtext[portal.MailHost.msgtext.index('\n\n'):]
+    >>> body = '\n\n'.join(portal.MailHost.msgtext.split('\n\n')[1:])
     >>> 'Subject' in body
     False
 
 Specifically list the field as one that should be included in the thank
 you page, and then it should show up in mail and thanks page::
 
-    >>> self.portal.testform['thank-you'].setShowAll(False)
-    >>> self.portal.testform['thank-you'].setShowFields(('topic',))
-    >>> self.portal.testform.mailer.setShowAll(False)
-    >>> self.portal.testform.mailer.setShowFields(('topic',))
+    >>> portal.testform['thank-you'].setShowAll(False)
+    >>> portal.testform['thank-you'].setShowFields(('topic',))
+    >>> portal.testform.mailer.setShowAll(False)
+    >>> portal.testform.mailer.setShowFields(('topic',))
+    >>> transaction.commit()
     >>> browser.goBack()
     >>> browser.getControl('Your E-Mail Address').value = 'test@example.com'
     >>> browser.getControl('Comments').value = 'Now with double the rockage...'
     >>> browser.getControl('Submit').click()
     <sent mail from ...to ['mdummy@address.com']>
 
-    >>> body = '\n\n'.join(self.portal.MailHost.msgtext.split('\n\n')[1:])
+    >>> app._p_jar.sync()
+    >>> body = '\n\n'.join(portal.MailHost.msgtext.split('\n\n')[1:])
     >>> 'Subject' in body
     True
 

--- a/Products/PloneFormGen/tests/ssl.txt
+++ b/Products/PloneFormGen/tests/ssl.txt
@@ -3,12 +3,36 @@
 
 First let's get our test browser and make sure that it won't re-raise Redirect errors::
 
-    >>> browser = self.browser
-    >>> self.setStatusCode('Redirect', 200)
+    >>> app = layer['app']
+    >>> portal = layer['portal']
+    >>> from Products.PloneFormGen.tests.pfgtc import MailHostMock
+    >>> portal.MailHost = MailHostMock()
+    >>> portal_url = portal.portal_url()
+    >>> request = layer['request']
+    >>> from plone.testing.z2 import Browser
+    >>> browser = Browser(app)
+    >>> from ZPublisher import HTTPResponse
+    >>> HTTPResponse.status_codes['redirect'] = 200
+
+Login to the portal:
+
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import login
+    >>> from plone.app.testing import TEST_USER_NAME
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> setRoles(portal, TEST_USER_ID, ['Manager'])
+    >>> login(portal, TEST_USER_NAME)
+    >>> import transaction
+    >>> transaction.commit()
+    >>> browser.open(portal_url + '/login_form')
+    >>> browser.getControl(name='__ac_name').value = TEST_USER_NAME
+    >>> browser.getControl(name='__ac_password').value = TEST_USER_PASSWORD
+    >>> browser.getControl(name='submit').click()
 
 Set up a form with the 'force SSL' setting on::
 
-    >>> browser.open(self.portal_url)
+    >>> browser.open(portal_url)
     >>> browser.getLink('Form Folder').click()
     >>> browser.getControl('Title').value = 'testform'
     
@@ -17,7 +41,7 @@ Set up a form with the 'force SSL' setting on::
     >>> browser.getControl('Save').click()
     >>> browser.url
     '.../testform/...'
-    >>> 'Bobo-Exception-Type' in self.browser.headers
+    >>> 'Bobo-Exception-Type' in browser.headers
     False
 
 Note that we didn't get forced to SSL immediately after creating the form.  (Which
@@ -34,9 +58,8 @@ Finally, let's use a new browser that isn't authenticated, and confirm that for 
 who doesn't have permission to edit the form, SSL will be forced on initial form load as
 well (so the user sees a security icon in their browser.) ::
 
-    >>> from Products.Five.testbrowser import Browser
-    >>> browser = Browser()
-    >>> browser.open(self.portal_url + '/testform')
+    >>> browser = Browser(app)
+    >>> browser.open(portal_url + '/testform')
     >>> browser.headers['Bobo-Exception-Type'] in ('Redirect', "<class 'zExceptions.Redirect'>")
     True
     

--- a/Products/PloneFormGen/tests/testCustomScript.py
+++ b/Products/PloneFormGen/tests/testCustomScript.py
@@ -8,12 +8,6 @@
 __author__  = 'Mikko Ohtamaa <mikko@redinnovation.com>'
 __docformat__ = 'plaintext'
 
-import os, sys
-
-
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
-
 try:
     from App.class_init import InitializeClass
 except ImportError:
@@ -142,8 +136,8 @@ InitializeClass(SecureFakeRequest)
 class TestCustomScript(pfgtc.PloneFormGenTestCase):
     """ Test FormCustomScriptAdapter functionality in PloneFormGen """
 
-    def afterSetUp(self):
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+    def setUp(self):
+        pfgtc.PloneFormGenTestCase.setUp(self)
 
         self.loginAsPortalOwner()
 
@@ -374,15 +368,3 @@ class TestCustomScript(pfgtc.PloneFormGenTestCase):
 #        req = FakeRequest(test_field="123")
 #        reply = adapter.onSuccess([], req)
 #        assert reply == "foo", "Script returned:" + str(reply)
-
-
-if  __name__ == '__main__':
-    framework()
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    from Products.PloneTestCase.layer import ZCMLLayer
-    suite = TestSuite()
-    suite.layer = ZCMLLayer
-    suite.addTest(makeSuite(TestCustomScript))
-    return suite

--- a/Products/PloneFormGen/tests/testDocTests.py
+++ b/Products/PloneFormGen/tests/testDocTests.py
@@ -1,8 +1,8 @@
 import unittest
 import doctest
+from plone.testing import layered
 
-from Testing import ZopeTestCase as ztc
-from Products.PloneFormGen.tests.pfgtc import PloneFormGenFunctionalTestCase
+from Products.PloneFormGen.tests.pfgtc import PFG_FUNCTIONAL_TESTING
 
 testfiles = (
     'browser.txt',
@@ -15,10 +15,10 @@ testfiles = (
 def test_suite():
     return unittest.TestSuite([
 
-        ztc.FunctionalDocFileSuite(
+        layered(doctest.DocFileSuite(
             f, package='Products.PloneFormGen.tests',
-            test_class=PloneFormGenFunctionalTestCase,
-            optionflags=doctest.REPORT_ONLY_FIRST_FAILURE | doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS)
+            optionflags=doctest.REPORT_ONLY_FIRST_FAILURE | doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS),
+        layer=PFG_FUNCTIONAL_TESTING)
 
             for f in testfiles
         ])

--- a/Products/PloneFormGen/tests/testEmbedding.py
+++ b/Products/PloneFormGen/tests/testEmbedding.py
@@ -123,7 +123,7 @@ class TestEmbedding(pfgtc.PloneFormGenTestCase):
         self.assertRaises(Retry, view)
 
         self.assertEqual(self.app.REQUEST._orig_env['PATH_INFO'],
-            '/plone/Members/test_user_1_/ff1/thank-you')
+            '/'.join(self.folder.getPhysicalPath()) + '/ff1/thank-you')
 
         # make sure the transaction was committed
         self.failUnless(committed)
@@ -132,7 +132,9 @@ class TestEmbedding(pfgtc.PloneFormGenTestCase):
         self.app.REQUEST._orig_env['PATH_TRANSLATED'] = '/VirtualHostBase/http/nohost:80/VirtualHostRoot'
         self.assertRaises(Retry, view)
         self.assertEqual(self.app.REQUEST._orig_env['PATH_INFO'],
-            '/VirtualHostBase/http/nohost:80/VirtualHostRoot/plone/Members/test_user_1_/ff1/thank-you')
+            '/VirtualHostBase/http/nohost:80/VirtualHostRoot' +
+            '/'.join(self.folder.getPhysicalPath()) +
+            '/ff1/thank-you')
 
         # clean up
         transaction.commit = real_transaction_commit

--- a/Products/PloneFormGen/tests/testEmbedding.py
+++ b/Products/PloneFormGen/tests/testEmbedding.py
@@ -1,8 +1,3 @@
-import os, sys
-
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
-
 from Products.PloneFormGen.tests import pfgtc
 
 import transaction
@@ -37,8 +32,8 @@ class TestEmbedding(pfgtc.PloneFormGenTestCase):
             form[key] = kwargs[key]
         return self.app.REQUEST
 
-    def afterSetUp(self):
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+    def setUp(self):
+        pfgtc.PloneFormGenTestCase.setUp(self)
         self.folder.invokeFactory('FormFolder', 'ff1')
         self.ff1 = getattr(self.folder, 'ff1')
         self.ff1.checkAuthenticator = False # no csrf protection
@@ -141,10 +136,3 @@ class TestEmbedding(pfgtc.PloneFormGenTestCase):
 
         # clean up
         transaction.commit = real_transaction_commit
-
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestEmbedding))
-    return suite

--- a/Products/PloneFormGen/tests/testEvents.py
+++ b/Products/PloneFormGen/tests/testEvents.py
@@ -2,12 +2,7 @@
 # Test PloneFormGen event-handler functionality
 #
 
-import os, sys
-
 from Products.PloneFormGen.tests import pfgtc
-
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
 
 
 class TestAdapterPaste(pfgtc.PloneFormGenTestCase):
@@ -19,8 +14,8 @@ class TestAdapterPaste(pfgtc.PloneFormGenTestCase):
         'FormCustomScriptAdapter',
     )
 
-    def afterSetUp(self):
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+    def setUp(self):
+        pfgtc.PloneFormGenTestCase.setUp(self)
         self.folder.invokeFactory('FormFolder', 'ff1')
         self.ff1 = getattr(self.folder, 'ff1')
 
@@ -50,10 +45,3 @@ class TestAdapterPaste(pfgtc.PloneFormGenTestCase):
             temp_adapter = self.ff1.restrictedTraverse('portal_factory/%s/%s_tmp' % (f,f))
         # temporary objects shouldn't be active on the form folder
         self.assertEqual(adapter_count, len(self.ff1.getActionAdapter()))
-
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestAdapterPaste))
-    return suite

--- a/Products/PloneFormGen/tests/testExportImport.py
+++ b/Products/PloneFormGen/tests/testExportImport.py
@@ -17,6 +17,7 @@ from Products.GenericSetup.tests.common import TarballTester
 from Products.PloneFormGen.tests import pfgtc
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import TEST_USER_ID
 from plone.app.testing.bbb import PTC_FIXTURE
 from plone.testing import z2
 
@@ -51,6 +52,12 @@ class ExportImportTester(pfgtc.PloneFormGenTestCase, TarballTester):
     """Base class for integration test suite for export/import """
 
     layer = GS_INTEGRATION_TESTING
+
+    def setUp(self):
+        super(ExportImportTester, self).setUp()
+        # This folder is created by the importer
+        self.folder = self.portal.Members.test_user_1_
+        self.folder.manage_setLocalRoles(TEST_USER_ID, ["Owner"])
 
     def _makeForm(self):
         self.folder.invokeFactory('FormFolder', 'ff1')

--- a/Products/PloneFormGen/tests/testExportImport.zcml
+++ b/Products/PloneFormGen/tests/testExportImport.zcml
@@ -1,0 +1,14 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:gs="http://namespaces.zope.org/genericsetup"
+           package="Products.PloneFormGen">
+
+    <gs:registerProfile
+        name="testing"
+        title="PloneFormGen testing"
+        description="Used for testing only"
+        directory="tests/profiles/testing"
+        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+</configure>

--- a/Products/PloneFormGen/tests/testFunctions.py
+++ b/Products/PloneFormGen/tests/testFunctions.py
@@ -1,12 +1,7 @@
 #
 # Integration tests. See other test modules for specific components.
 #
-
-import os, sys
-
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
-
+import sys
 import plone.protect
 
 from Products.PloneFormGen.tests import pfgtc
@@ -39,8 +34,8 @@ class TestFunctions(pfgtc.PloneFormGenTestCase):
         return self.request
 
 
-    def afterSetUp(self):
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+    def setUp(self):
+        pfgtc.PloneFormGenTestCase.setUp(self)
         self.folder.invokeFactory('FormFolder', 'ff1')
         self.ff1 = getattr(self.folder, 'ff1')
         self.mailhost = self.folder.MailHost
@@ -668,10 +663,3 @@ class TestFunctions(pfgtc.PloneFormGenTestCase):
         res = jsvars()
         self.assertEqual(res.find("pfgQEdit.messages = {"), 0)
         self.failUnless(res.find("ORDER_MSG: 'Order'") > 0)
-
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestFunctions))
-    return suite

--- a/Products/PloneFormGen/tests/testInterfaces.py
+++ b/Products/PloneFormGen/tests/testInterfaces.py
@@ -1,11 +1,6 @@
 #
 # Integration tests for interaction with GenericSetup infrastructure
 #
-
-import os, sys
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
-
 from zope.interface.verify import verifyObject, verifyClass
 from zope.component import getMultiAdapter
 
@@ -19,8 +14,8 @@ class TestFormGenInterfaces(pfgtc.PloneFormGenTestCase):
     """ Some boilerplate-ish tests to confirm that that classes
         and instances confirm to the interface contracts intended.
     """
-    def afterSetUp(self):
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+    def setUp(self):
+        pfgtc.PloneFormGenTestCase.setUp(self)
 
         # add form folder for use in tests
         self.folder.invokeFactory('FormFolder', 'ff1')
@@ -40,13 +35,3 @@ class TestFormGenInterfaces(pfgtc.PloneFormGenTestCase):
     def testContentClassInterfaces(self):
         self.failUnless(interfaces.IPloneFormGenFieldset.implementedBy(content.fieldset.FieldsetFolder))
         self.failUnless(verifyClass(interfaces.IPloneFormGenFieldset, content.fieldset.FieldsetFolder))
-
-
-if  __name__ == '__main__':
-    framework()
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestFormGenInterfaces))
-    return suite

--- a/Products/PloneFormGen/tests/testLikertField.py
+++ b/Products/PloneFormGen/tests/testLikertField.py
@@ -1,17 +1,10 @@
 #
 # Likert Field related tests
 #
-
-import os, sys, email
-
 from ZPublisher.HTTPRequest import record
-
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
 
 from Products.PloneFormGen.tests import pfgtc
 
-from Products.CMFCore.utils import getToolByName
 
 class FakeRequest(dict):
 
@@ -24,10 +17,10 @@ class TestLikertField(pfgtc.PloneFormGenTestCase):
         so we don't bother with it here.
     """
 
-    def afterSetUp(self):
+    def setUp(self):
         # build a form folder, add a Likert Field and
         # a saver.
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+        pfgtc.PloneFormGenTestCase.setUp(self)
         self.folder.invokeFactory('FormFolder', 'ff1')
         self.ff1 = getattr(self.folder, 'ff1')
         self.ff1.invokeFactory('FormLikertField', 'lf')
@@ -78,14 +71,3 @@ class TestLikertField(pfgtc.PloneFormGenTestCase):
         request = FakeRequest(topic = 'test subject', replyto='test@test.org',
                               comments='test comments', lf=rating_req_val)
         self.failUnless("1: 2, 2: 3" in self.ff1.lf.htmlValue(request))
-
-
-
-if  __name__ == '__main__':
-    framework()
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestLikertField))
-    return suite

--- a/Products/PloneFormGen/tests/testMailer.py
+++ b/Products/PloneFormGen/tests/testMailer.py
@@ -2,13 +2,7 @@
 #
 # Integeration tests specific to the mailer
 #
-
 import email
-import os
-import sys
-
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
 
 from Products.PloneFormGen.tests import pfgtc
 
@@ -22,8 +16,8 @@ class TestFunctions(pfgtc.PloneFormGenTestCase):
         self.messageText = messageText
         self.messageBody = '\n\n'.join(messageText.split('\n\n')[1:])
 
-    def afterSetUp(self):
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+    def setUp(self):
+        pfgtc.PloneFormGenTestCase.setUp(self)
         self.folder.invokeFactory('FormFolder', 'ff1')
         self.ff1 = getattr(self.folder, 'ff1')
         self.ff1.checkAuthenticator = False # no csrf protection
@@ -375,12 +369,3 @@ class TestFunctions(pfgtc.PloneFormGenTestCase):
             'test@testme.com' in self.mto and
             'test1@testme.com' in self.mto
         )
-
-if  __name__ == '__main__':
-    framework()
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestFunctions))
-    return suite

--- a/Products/PloneFormGen/tests/testSaver.py
+++ b/Products/PloneFormGen/tests/testSaver.py
@@ -1,11 +1,6 @@
 # Integration tests specific to save-data adapter.
 #
-
-import os, sys
-
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
-
+import sys
 from ZPublisher.HTTPRequest import HTTPRequest
 from ZPublisher.HTTPResponse import HTTPResponse
 import zExceptions
@@ -36,8 +31,8 @@ def FakeRequest(method="GET", add_auth=False, **kwargs):
 class TestFunctions(pfgtc.PloneFormGenTestCase):
     """ test save data adapter """
 
-    def afterSetUp(self):
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+    def setUp(self):
+        pfgtc.PloneFormGenTestCase.setUp(self)
         self.folder.invokeFactory('FormFolder', 'ff1')
         self.ff1 = getattr(self.folder, 'ff1')
 
@@ -384,9 +379,3 @@ class TestFunctions(pfgtc.PloneFormGenTestCase):
         self.assertEqual(row[1], 'test comments')
 
     # the csrf test has moved to browser.txt
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestFunctions))
-    return suite

--- a/Products/PloneFormGen/tests/testSetup.py
+++ b/Products/PloneFormGen/tests/testSetup.py
@@ -1,11 +1,6 @@
 #
 # Test PloneFormGen initialisation and set-up
 #
-
-import os, sys
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
-
 from AccessControl import Unauthorized
 
 from Products.PloneFormGen.tests import pfgtc
@@ -26,8 +21,8 @@ def getAddPermission(product, name):
 class TestInstallation(pfgtc.PloneFormGenTestCase):
     """Ensure product is properly installed"""
 
-    def afterSetUp(self):
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+    def setUp(self):
+        pfgtc.PloneFormGenTestCase.setUp(self)
 
         self.kupu         = getattr(self.portal, 'kupu_library_tool', None)
         self.skins        = self.portal.portal_skins
@@ -269,8 +264,8 @@ class TestContentCreation(pfgtc.PloneFormGenTestCase):
     sampleContentIds = ('mailer', 'replyto', 'topic', 'comments', 'thank-you')
 
 
-    def afterSetUp(self):
-        pfgtc.PloneFormGenTestCase.afterSetUp(self)
+    def setUp(self):
+        pfgtc.PloneFormGenTestCase.setUp(self)
         self.folder.invokeFactory('FormFolder', 'ff1')
         self.ff1 = getattr(self.folder, 'ff1')
 
@@ -562,11 +557,3 @@ class TestGPG(pfgtc.PloneFormGenTestCase):
             print "\nSkipping GPG tests; gpg binary not found"
         else:
             self.assertRaises(GPGError, gpg.encrypt, 'spam', 'eggs')
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestInstallation))
-    suite.addTest(makeSuite(TestContentCreation))
-    suite.addTest(makeSuite(TestGPG))
-    return suite

--- a/Products/PloneFormGen/tests/testTools.py
+++ b/Products/PloneFormGen/tests/testTools.py
@@ -2,12 +2,6 @@
 # Test PloneFormGen top-level functionality
 #
 
-import os, sys
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
-
-import zope
-
 from Products.PloneFormGen.tests import pfgtc
 
 from Products.CMFCore.utils import getToolByName
@@ -119,14 +113,3 @@ class TestTools(pfgtc.PloneFormGenTestCase):
                 oid = role['id']
         self.failUnless( mid )
         self.failUnless( oid )
-
-
-
-if  __name__ == '__main__':
-    framework()
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestTools))
-    return suite

--- a/Products/PloneFormGen/tests/testValidators.py
+++ b/Products/PloneFormGen/tests/testValidators.py
@@ -2,10 +2,6 @@
 # Test PloneFormGen initialisation and set-up
 #
 
-import os, sys
-if __name__ == '__main__':
-    execfile(os.path.join(sys.path[0], 'framework.py'))
-
 from Products.PloneFormGen.tests import pfgtc
 
 from Products.PloneFormGen.content import validationMessages
@@ -126,14 +122,3 @@ class TestCustomValidatorMessages(pfgtc.PloneFormGenTestCase):
         self.failUnlessEqual( v.validate('pfgv_isZipCode', 'T2X 1V4'), 1)
         self.failUnlessEqual( v.validate('pfgv_isZipCode', 'T2X1V4'), 1)
         self.failUnlessEqual( v.validate('pfgv_isZipCode', 't2x 1v4'), 1)
-
-
-if  __name__ == '__main__':
-    framework()
-
-def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(TestCustomValidators))
-    suite.addTest(makeSuite(TestCustomValidatorMessages))
-    return suite

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -6,10 +6,22 @@ package-name = Products.PloneFormGen
 
 extensions=mr.developer
 auto-checkout=
-    plone.app.jquerytools
-    collective.js.jqueryui
+#    plone.app.jquerytools
+#    collective.js.jqueryui
+
+[test]
+eggs +=
+    plone.app.testing
+    plone.app.jquery
 
 [sources]
-plone.app.jquerytools = git git://github.com/plone/plone.app.jquerytools.git
-collective.js.jqueryui = git git://github.com/collective/collective.js.jqueryui.git
-Products.Archetypes = git git://github.com/plone/Products.Archetypes.git
+plone.app.jquerytools = git git://github.com/plone/plone.app.jquerytools.git branch=1.5.x
+collective.js.jqueryui = git git://github.com/collective/collective.js.jqueryui.git branch=1.9.x
+Products.Archetypes = git git://github.com/plone/Products.Archetypes.git branch=1.9.x
+
+[versions]
+plone.app.testing = 4.2.5
+plone.testing = 4.0.13
+collective.js.jqueryui = 1.9.2.0
+plone.app.jquery = 1.4.4
+plone.app.jquerytools = 1.5.7

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -6,10 +6,21 @@ package-name = Products.PloneFormGen
 
 extensions=mr.developer
 auto-checkout=
-    plone.app.jquerytools
-    collective.js.jqueryui
+#    plone.app.jquerytools
+#    collective.js.jqueryui
+
+[test]
+eggs +=
+    plone.app.testing
 
 [sources]
 plone.app.jquerytools = git git://github.com/plone/plone.app.jquerytools.git
-collective.js.jqueryui = git git://github.com/collective/collective.js.jqueryui.git
-Products.Archetypes = git git://github.com/plone/Products.Archetypes.git
+collective.js.jqueryui = git git://github.com/collective/collective.js.jqueryui.git branch=1.9.x
+Products.Archetypes = git git://github.com/plone/Products.Archetypes.git branch=1.9.x
+
+[versions]
+plone.app.testing = 4.2.5
+plone.testing = 4.0.13
+collective.js.jqueryui = 1.10.4
+plone.app.jquery = 1.7.2
+plone.app.jquerytools = 1.6.3

--- a/travis.cfg
+++ b/travis.cfg
@@ -2,6 +2,8 @@
 # Plone 4.2 only (overridden in Plone >=4.3)
 collective.js.jqueryui = 1.8.16.9
 pep8 = 1.5.7
+plone.app.testing = 4.2.5
+plone.testing = 4.0.13
 setuptools =
 
 [buildout]


### PR DESCRIPTION
Mostly quickedit workarounds for auto-CSRF "protection", but also for changes to globalstatusmessage use in embedded view.  Move tests to plone.app.testing PTC compatilbity layer.  Tests are confirmed running on Plone 4.3