### PR TITLE
Fix Travis for 1.7 maintenance branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python: 2.7
 env:
   - PLONE_VERSION=4.2
   - PLONE_VERSION=4.3
-  - PLONE_VERSION=5.0
 matrix:
   include:
     - python: 2.6
@@ -11,7 +10,6 @@ matrix:
   allow_failures:
     - python: 2.6
       env: PLONE_VERSION=4.1
-    - env: PLONE_VERSION=5.0
   fast_finish: true
 install:
   - sed -ie "s#travis-4.x.cfg#travis-$PLONE_VERSION.x.cfg#" travis.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+sudo: false
 language: python
 python: 2.7
+cache:
+  directories:
+    - buildout-cache
 env:
   - PLONE_VERSION=4.2
   - PLONE_VERSION=4.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ install:
   - mkdir -p buildout-cache/downloads
   - python bootstrap.py -c travis.cfg
   - bin/buildout -c travis.cfg annotate
+# Try this twice, to avoid a possible problem, on Plone 4.3.7 at
+# least, with setuptools as directory instead of zipped egg.
+  - bin/buildout -c travis.cfg -N -q || true
   - bin/buildout -c travis.cfg -N -q
 before_script:
   - export DISPLAY=:99.0

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -25,7 +25,10 @@ import tempfile
 
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -35,13 +38,14 @@ Bootstraps a buildout-based project.
 Simply run this script in a directory containing a buildout.cfg, using the
 Python that you want bin/buildout to use.
 
-Note that by using --find-links to point to local resources, you can keep 
+Note that by using --find-links to point to local resources, you can keep
 this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -59,36 +63,57 @@ parser.add_option("-f", "--find-links",
 parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
-
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
 
 ######################################################################
 # load/install setuptools
 
 try:
-    if options.allow_site_packages:
-        import setuptools
-        import pkg_resources
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
 
 ez = {}
-exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
 if not options.allow_site_packages:
     # ez_setup imports site, which adds site packages
-    # this will remove them from the path to ensure that incompatible versions 
+    # this will remove them from the path to ensure that incompatible versions
     # of setuptools are not in the path
     import site
-    # inside a virtualenv, there is no 'getsitepackages'. 
+    # inside a virtualenv, there is no 'getsitepackages'.
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
         for sitepackage_path in site.getsitepackages():
-            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
 ez['use_setuptools'](**setup_args)
 import setuptools
 import pkg_resources
@@ -104,7 +129,12 @@ for path in sys.path:
 
 ws = pkg_resources.working_set
 
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
 cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
        'from setuptools.command.easy_install import main; main()',
        '-mZqNxd', tmpeggs]
 
@@ -117,21 +147,23 @@ find_links = os.environ.get(
 if find_links:
     cmd.extend(['-f', find_links])
 
-setuptools_path = ws.find(
-    pkg_resources.Requirement.parse('setuptools')).location
-
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
     _final_parts = '*final-', '*final'
 
     def _final_version(parsed_version):
-        for part in parsed_version:
-            if (part[:1] == '*') and (part not in _final_parts):
-                return False
-        return True
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
     index = setuptools.package_index.PackageIndex(
         search_path=[setuptools_path])
     if find_links:
@@ -156,7 +188,7 @@ if version:
 cmd.append(requirement)
 
 import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,6 @@ setup(name='Products.PloneFormGen',
       extras_require={
           'test': [
               'Products.PloneTestCase',
-              # needed in Plone 5.0
-              'plone.app.testing',
-              'plone.testing',
           ],
           'loadtest': ['collective.funkload'],
       },

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(name='Products.PloneFormGen',
       extras_require={
           'test': [
               'Products.PloneTestCase',
+              'plone.protect>=2.0.2',
           ],
           'loadtest': ['collective.funkload'],
       },

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -13,3 +13,6 @@ auto-checkout=
 plone.app.jquerytools = git git://github.com/plone/plone.app.jquerytools.git
 collective.js.jqueryui = git git://github.com/collective/collective.js.jqueryui.git
 Products.Archetypes = git git://github.com/plone/Products.Archetypes.git
+
+[versions]
+plone.protect = 2.0.2

--- a/travis.cfg
+++ b/travis.cfg
@@ -3,6 +3,9 @@
 collective.js.jqueryui = 1.8.16.9
 pep8 = 1.5.7
 setuptools =
+# We need a fresher plone.protect on 4.1:
+plone.protect = 2.0.2
+
 
 [buildout]
 extends =


### PR DESCRIPTION
- Do not test on Plone 5. That is what master is for.
- Require newer plone.protect in tests, to hopefully fix the Plone 4.1 run.
- non-sudo travis

@smcmahon Do you agree on those changes?
Also, do you actually want to hang on to 4.1 support?

There is also currently a weird buildout/setuptools failure, which I hope will just go away, without anything in this pull request doing it:
```
IOError: [Errno 21] Is a directory: '/home/travis/build/smcmahon/
Products.PloneFormGen/buildout-cache/eggs/setuptools-18.3.2-py2.7.egg'
```