### PR TITLE
Add option to download data from saveDataAdapter in excel format

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,9 @@ Change History
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add option to download data from saveDataAdapter in excel format 
+  Excel download depends on the availability of the 'xlwt' python package.
+  [tmog]
 
 
 1.8.0 (2015-10-01)

--- a/Products/PloneFormGen/content/saveDataAdapter.py
+++ b/Products/PloneFormGen/content/saveDataAdapter.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     has_xls = False
 
+from urlparse import urlparse
+
 from AccessControl import ClassSecurityInfo
 
 from BTrees.IOBTree import IOBTree
@@ -466,6 +468,17 @@ class FormSaveDataAdapter(FormActionAdapter):
             for col_num, col in enumerate(row):
                 if type(col) is unicode:
                     col = col.encode(self.getCharset())
+
+                if urlparse(col).scheme in ('http', 'https'):
+                    col = xlwt.Formula('HYPERLINK("%(url)s")' % dict(url=col))
+                else:
+                    for format in (int, float):
+                        try:
+                            col = format(col)
+                            break
+                        except ValueError:
+                            pass
+
                 sheet.write(row_num, col_num, col)
             row_num += 1
 

--- a/Products/PloneFormGen/content/saveDataAdapter.py
+++ b/Products/PloneFormGen/content/saveDataAdapter.py
@@ -464,7 +464,9 @@ class FormSaveDataAdapter(FormActionAdapter):
 
         for row in self.getSavedFormInput():
             for col_num, col in enumerate(row):
-                sheet.write(row_num, col_num, col.encode(self.getCharset()))
+                if type(col) is unicode:
+                    col = col.encode(self.getCharset())
+                sheet.write(row_num, col_num, col)
             row_num += 1
 
         string_buffer = StringIO()


### PR DESCRIPTION
Allows excel download when the 'xlwt' python package is available.
