### PR TITLE
Fixed showing translations of help text. [master]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,12 @@ Change History
 1.8.2 (unreleased)
 ------------------
 
+- Fixed showing translations of help text.  Since security release
+  1.8.1, help text was showing up with only the message id, for
+  example ``help_placeholder``.
+  Fixes `issue #178 <https://github.com/smcmahon/Products.PloneFormGen/issues/178>`_.
+  [maurits]
+
 - Use formActionOverride action in embedded view.  [fRiSi]
 
 

--- a/Products/PloneFormGen/content/field_utils.py
+++ b/Products/PloneFormGen/content/field_utils.py
@@ -1,5 +1,7 @@
-import cgi
 from Products.Archetypes.Renderer import renderer
+from zope.i18n import translate
+
+import cgi
 
 
 class ATWidgetWrapper(object):
@@ -22,6 +24,7 @@ class ATWidgetWrapper(object):
     def wDescription(self, instance, **kwargs):
         value = self.obj.description
         if value:
+            value = translate(value, context=instance.REQUEST)
             return cgi.escape(value)
         else:
             return value


### PR DESCRIPTION
Since security release 1.8.1, help text was showing up with only the message id, for example `help_placeholder`.

This fixes issue #178 for Plone 5.