### PR TITLE
Fixed UnicodeDecodeError when vocabulary value is a non-ascii string. [1.7]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Change History
 1.7.22 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed UnicodeDecodeError when vocabulary value is a non-ascii string.
+  This could happen in selection and multi selection fields.
+  [maurits]
 
 
 1.7.21 (2016-12-06)

--- a/Products/PloneFormGen/content/fields.py
+++ b/Products/PloneFormGen/content/fields.py
@@ -780,7 +780,10 @@ class FGSelectionField(BaseFormField):
         vocabulary = self.fgField.Vocabulary(self)
         v = vocabulary.getValue(vu) or vu
 
-        return cgi.escape(v.encode(charset))
+        # v might be unicode or string.  We need string.
+        if isinstance(v, unicode):
+            v = v.encode(charset)
+        return cgi.escape(v)
 
 
 registerATCT(FGSelectionField, PROJECTNAME)
@@ -890,11 +893,14 @@ class FGMultiSelectField(BaseFormField):
                 # so decode the key before lookup
                 ku = k.decode(charset)
                 v = vocabulary.getValue(ku) or ku
+                # v might be unicode or string.  We need string.
+                if isinstance(v, unicode):
+                    v = v.encode(charset)
                 result.append(v)
 
-        value = u', '.join(result)
+        value = ', '.join(result)
 
-        return cgi.escape(value.encode(charset))
+        return cgi.escape(value)
 
 
 registerATCT(FGMultiSelectField, PROJECTNAME)

--- a/Products/PloneFormGen/tests/testFunctions.py
+++ b/Products/PloneFormGen/tests/testFunctions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Integration tests. See other test modules for specific components.
 #
@@ -204,7 +205,9 @@ class TestFunctions(pfgtc.PloneFormGenTestCase):
         """ Test field htmlValue method of selection field """
 
         self.ff1.invokeFactory('FormSelectionField', 'fsf')
-        self.ff1.fsf.fgVocabulary = ('1|one', '2|two', '3|three',)
+        # Let's mix ascii and non-ascii strings and unicode.
+        self.ff1.fsf.fgVocabulary = (
+            '1|one', '2|two', '3|three', u'4|fo\xfcr', '5|f\xc3\xacve')
 
         # first test inside the vocabulary
         request = self.fakeRequest(fsf = '2')
@@ -222,12 +225,23 @@ class TestFunctions(pfgtc.PloneFormGenTestCase):
         val = self.ff1['fsf'].htmlValue(request)
         self.assertEqual( val, '&amp;')
 
+        # Now test unicode
+        request = self.fakeRequest(fsf = '4')
+        val = self.ff1['fsf'].htmlValue(request)
+        self.assertEqual(val, u'fo\xfcr'.encode('utf-8'))
+
+        # And test a non-ascii string
+        request = self.fakeRequest(fsf = '5')
+        val = self.ff1['fsf'].htmlValue(request)
+        self.assertEqual(val, 'f\xc3\xacve')
 
     def testHtmlValueMultiSelectionField(self):
         """ Test field htmlValue method of multi-selection field """
 
         self.ff1.invokeFactory('FormMultiSelectionField', 'fsf')
-        self.ff1.fsf.fgVocabulary = ('1|one', '2|two', '3|three',)
+        # Let's mix ascii and non-ascii strings and unicode.
+        self.ff1.fsf.fgVocabulary = (
+            '1|one', '2|two', '3|three', u'4|fo\xfcr', '5|f\xc3\xacve')
 
         # first test inside the vocabulary
         request = self.fakeRequest(fsf = ['2', '3', ''])
@@ -250,6 +264,11 @@ class TestFunctions(pfgtc.PloneFormGenTestCase):
         val = self.ff1['fsf'].htmlValue(request)
         self.assertEqual( val, 'one, 7')
 
+        # Now test ascii and non-ascii strings and unicode.
+        request = self.fakeRequest(fsf = ['1', '4', '5'])
+        val = self.ff1['fsf'].htmlValue(request)
+        self.assertEqual(val, 'one, fo\xc3\xbcr, f\xc3\xacve')
+        self.assertEqual(val.decode('utf-8'), u'one, fo\xfcr, f\xecve')
 
     def testHtmlValueDateField(self):
         """ Test field htmlValue method of date field """


### PR DESCRIPTION
This could happen in selection and multi selection fields.

To try it out, create a Python Script in the ZMI:

```
selections = (
    ("- select -", u"- select -"),
    ("one", "Oné".decode('utf-8')),  # works best
    ("two", "Twö"),  # will give UnicodeDecodeError without the fix
    ("three", u"Threë"),  # will look ugly with or without the fix
)
return selections
```

Then refer to this script in an overrides of a selection or multi selection field.

(BTW, there are subtle differences between a ZMI script and a normal Python prompt  in how the above lines show up, but never mind that.)