### PR TITLE
Adding getColumnNames logic to getColumnTitles

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,9 @@ Change History
   of a tag not being closed
   [datakurre]
 
+- Fix issue where logic in FormSaveDataAdapter's getColumnTitles was
+  different than the logic for getColumnNames.
+  [mikerenfro]
 
 1.8.3 (2016-12-06)
 ------------------

--- a/Products/PloneFormGen/content/saveDataAdapter.py
+++ b/Products/PloneFormGen/content/saveDataAdapter.py
@@ -381,8 +381,10 @@ class FormSaveDataAdapter(FormActionAdapter):
     def getColumnTitles(self, excludeServerSide=True):
         # """Returns a list of column titles"""
 
+        showFields = getattr(self, 'showFields', [])
         names = [field.widget.label for field
-                 in self.fgFields(displayOnly=True, excludeServerSide=excludeServerSide)]
+                 in self.fgFields(displayOnly=True, excludeServerSide=excludeServerSide)
+                 if not showFields or field.getName() in showFields]
         for f in self.ExtraData:
             names.append(self.vocabExtraDataDL().getValue(f, ''))
 


### PR DESCRIPTION
As noted in [Plone Community: Filtering CSV data from PloneFormGen for display](https://community.plone.org/t/filtering-csv-data-from-ploneformgen-for-display/3607), it appears that the logic used to show column headers for displaying a CSV is different than that for downloading it. This set of changes uses the same (hopefully correct) logic for both types of headers.