### PR TITLE
Fixed bootstrapping.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - buildout-cache
 install:
   - mkdir -p buildout-cache/{eggs,downloads}
-  - python bootstrap-buildout.py
+  - python bootstrap-buildout.py --buildout-version=2.5.3
   - bin/buildout
 script:
   - bin/test

--- a/Products/PloneFormGen/tests/attachment.txt
+++ b/Products/PloneFormGen/tests/attachment.txt
@@ -10,6 +10,7 @@ File attachments
     >>> import cStringIO
     >>> from plone.testing.z2 import Browser
     >>> browser = Browser(app)
+    >>> browser.handleErrors = False
 
 Login to the portal:
 

--- a/Products/PloneFormGen/tests/browser.txt
+++ b/Products/PloneFormGen/tests/browser.txt
@@ -9,6 +9,7 @@ Integration tests
     >>> request = layer['request']
     >>> from plone.testing.z2 import Browser
     >>> browser = Browser(app)
+    >>> browser.handleErrors = False
 
 Login to the portal:
 
@@ -150,41 +151,40 @@ Attempts to use clearSavedFormInput without auth should be forbidden::
     >>> browser.open(portal_url + '/testform/saver/clearSavedFormInput')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 403: Forbidden
-
+    Forbidden: Form authenticator is invalid.
 
 Attempts to use gpg_services TTW should be fruitless::
 
     >>> browser.open(portal_url + '/testform/@@gpg_services/encrypt?data=XXX&recipient_key_id=yyy')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
 Attempts to read the success action TTW should be fruitless::
 
     >>> browser.open(portal_url + '/testform/fgGetSuccessAction')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
 That should also be true for fields::
 
     >>> browser.open(portal_url + '/testform/comments/fgGetSuccessAction')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
 Attempts to set mailer body TTW should fail
     >>> browser.open(portal_url + '/testform/mailer/setBody_pt?value=stuff')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
 Attempts to read mailer body TTW should fail
     >>> browser.open(portal_url + '/testform/mailer/body_pt')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
 We want to test security on the custom script adapter. Let's add one::
 
@@ -201,48 +201,48 @@ Attempts to set script body TTW should fail::
     >>> browser.open(portal_url + '/testform/test-script-adapter/updateScript?body=raise%2010&role=none')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
 Attempts to run the script TTW should fail::
 
     >>> browser.open(portal_url + '/testform/test-script-adapter/onSuccess?fields=')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
     >>> browser.open(portal_url + '/testform/test-script-adapter/scriptBody?fields=')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
     >>> browser.open(portal_url + '/testform/test-script-adapter/executeCustomScript?fields=&form=&req=')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
 Attempts to use onSuccess TTW should fail::
 
     >>> browser.open(portal_url + '/testform/saver/onSuccess?fields=&request=')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
 Attempts to read our special member attributes TTW should fail::
 
     >>> browser.open(portal_url + '/testform/memberId')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
     >>> browser.open(portal_url + '/testform/memberFullName')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
     >>> browser.open(portal_url + '/testform/memberEmail')
     Traceback (most recent call last):
     ...
-    HTTPError: HTTP Error 404: Not Found
+    NotFound:...
 
 Archetypes does not quote an input widget's description. That's fine for Archetypes,
 where descriptions are set in code, but it's not OK when form help may be

--- a/Products/PloneFormGen/tests/serverside_field.txt
+++ b/Products/PloneFormGen/tests/serverside_field.txt
@@ -2,7 +2,7 @@ Server-side only field
 ----------------------
 
 Get our test browser::
-    
+
     >>> app = layer['app']
     >>> portal = layer['portal']
     >>> from Products.PloneFormGen.tests.pfgtc import MailHostMock
@@ -11,10 +11,11 @@ Get our test browser::
     >>> request = layer['request']
     >>> from plone.testing.z2 import Browser
     >>> browser = Browser(app)
+    >>> browser.handleErrors = False
 
 Add a new form folder and mark the subject input variable as a server side variable.
 (It needs a non-empty default value because it's set as required.) ::
-  
+
     >>> from plone.app.testing import setRoles
     >>> from plone.app.testing import login
     >>> from plone.app.testing import TEST_USER_NAME
@@ -40,7 +41,7 @@ Login to the portal:
     >>> browser.getControl(name='submit').click()
 
 And confirm that the server-side field is absent from the rendered form::
-    
+
     >>> browser.open(portal_url + '/testform')
     >>> 'id="archetypes-fieldname-topic"' in  browser.contents
     False

--- a/Products/PloneFormGen/tests/ssl.txt
+++ b/Products/PloneFormGen/tests/ssl.txt
@@ -11,6 +11,7 @@ First let's get our test browser and make sure that it won't re-raise Redirect e
     >>> request = layer['request']
     >>> from plone.testing.z2 import Browser
     >>> browser = Browser(app)
+    >>> browser.handleErrors = False
     >>> from ZPublisher import HTTPResponse
     >>> HTTPResponse.status_codes['redirect'] = 200
 
@@ -35,9 +36,9 @@ Set up a form with the 'force SSL' setting on::
     >>> browser.open(portal_url)
     >>> browser.getLink('Form Folder').click()
     >>> browser.getControl('Title').value = 'testform'
-    
+
     >>> browser.getControl(name='forceSSL:boolean').value = '1'
-    
+
     >>> browser.getControl('Save').click()
     >>> browser.url
     '.../testform/...'
@@ -62,4 +63,4 @@ well (so the user sees a security icon in their browser.) ::
     >>> browser.open(portal_url + '/testform')
     >>> browser.headers['Bobo-Exception-Type'] in ('Redirect', "<class 'zExceptions.Redirect'>")
     True
-    
+

--- a/bootstrap-buildout.py
+++ b/bootstrap-buildout.py
@@ -25,7 +25,10 @@ import tempfile
 
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -40,8 +43,9 @@ this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -59,25 +63,33 @@ parser.add_option("-f", "--find-links",
 parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
 parser.add_option("--setuptools-version",
-                  help="use a specific setuptools version")
-
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
 
 ######################################################################
 # load/install setuptools
 
 try:
-    if options.allow_site_packages:
-        import setuptools
-        import pkg_resources
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
 
 ez = {}
-exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
 if not options.allow_site_packages:
     # ez_setup imports site, which adds site packages
@@ -88,12 +100,19 @@ if not options.allow_site_packages:
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
         for sitepackage_path in site.getsitepackages():
-            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
 
 if options.setuptools_version is not None:
     setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
 
 ez['use_setuptools'](**setup_args)
 import setuptools
@@ -110,7 +129,12 @@ for path in sys.path:
 
 ws = pkg_resources.working_set
 
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
 cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
        'from setuptools.command.easy_install import main; main()',
        '-mZqNxd', tmpeggs]
 
@@ -123,11 +147,8 @@ find_links = os.environ.get(
 if find_links:
     cmd.extend(['-f', find_links])
 
-setuptools_path = ws.find(
-    pkg_resources.Requirement.parse('setuptools')).location
-
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
@@ -167,7 +188,7 @@ if version:
 cmd.append(requirement)
 
 import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -29,9 +29,9 @@ defaults = ['-s', 'Products.PloneFormGen', '--auto-color', '--auto-progress']
 
 
 [versions]
-setuptools = 6.1
-zc.buildout = 2.2.5
-zc.recipe.egg = 2.0.1
+setuptools = 33.1.1
+zc.buildout = 2.5.3
+zc.recipe.egg = 2.0.3
 
 flake8 = 2.3.0
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,7 +1,7 @@
 [buildout]
 eggs-directory = ${buildout:directory}/buildout-cache/eggs
 download-cache = ${buildout:directory}/buildout-cache/downloads
-extends = http://dist.plone.org/release/5.0-latest/versions.cfg
+extends = http://dist.plone.org/release/5.0.6/versions.cfg
 extensions = mr.developer
 parts =
     instance


### PR DESCRIPTION
Both locally and on Travis.
Note that you need to specify the zc.buildout version when bootstrapping:
python bootstrap-buildout.py --buildout-version=2.5.3
For setuptools we use the latest that ez_setup.py gives us, which will remain 33.1.1.