### PR TITLE
Fix/ratescalefield unicode error

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Change History
 1.8.4 (unreleased)
 ------------------
 
+- Fix UnicodeDecodeError: RateScaleField with non-ascii values and without
+  Thank-you-page.
+  ref: https://github.com/smcmahon/Products.PloneFormGen/issues/98
+  [vkarppinen]
+
 - Remove collective.cover adapter reference. (closes `#194`_).
   [rodfersou]
 

--- a/Products/PloneFormGen/skins/PloneFormGen/fg_result_embedded_view.pt
+++ b/Products/PloneFormGen/skins/PloneFormGen/fg_result_embedded_view.pt
@@ -4,7 +4,8 @@
     <tal:block repeat="field here/fgFields">
       <tal:block tal:define="fname field/getName">
         <dt tal:content="field/widget/label" />
-        <dd tal:content="python:request.form.get(fname, 'No Input')" />
+        <dd tal:define="field_value python:str(request.form.get(fname, 'No Input')).decode('utf-8')"
+            tal:content="field_value" />
       </tal:block>
     </tal:block>
   </dl>


### PR DESCRIPTION
Fix UnicodeDecodeError on ratescalefield with non-ascii values as described in #98.

