### PR TITLE
Only load quickedit resources on quickedit view.

### DIFF
--- a/Products/PloneFormGen/profiles/default/registry.xml
+++ b/Products/PloneFormGen/profiles/default/registry.xml
@@ -20,7 +20,7 @@
         <value key="resources">
             <element>pfgquickedit</element>
         </value>
-        <value key="expression">python: object.portal_type == 'FormFolder' and member is not None</value>
+        <value key="expression">python: object.portal_type == 'FormFolder' and member is not None and 'quickedit' in request.URL</value>
         <value key="enabled">True</value>
         <value key="compile">False</value>
         <value key="jscompilation">++plone++pfgquickedit/quickedit-min.js</value>


### PR DESCRIPTION
Sometimes the people using the form are members, but can't edit the form. Before this change, the form looks ugly for them, taking only half the available space. Quickedit only needed in quickedit view.