### PR TITLE
Fix UnicodeDecode errors when displaying the result page.

### DIFF
--- a/Products/PloneFormGen/skins/PloneFormGen/fg_result_embedded_view.pt
+++ b/Products/PloneFormGen/skins/PloneFormGen/fg_result_embedded_view.pt
@@ -3,7 +3,7 @@
     <tal:block repeat="field here/fgFields">
       <tal:block tal:define="fname field/getName">
         <dt tal:content="field/widget/label" />
-        <dd tal:content="python:request.form.get(fname, 'No Input')" />
+        <dd tal:content="python: str(request.form.get(fname, 'No Input')).decode('utf-8')" />
       </tal:block>
     </tal:block>
   </dl>


### PR DESCRIPTION
We experienced an issue on FormLikertFields in the result page when using unicode characters in the answers. It was caused because the result page is implicitly casting whatever it gets from the fields to str. I added an explicit cast and conversion to utf-8.

We need access to pypi for making a release as soon as possible. Please could you grant permissions to the "timo" pypi username?

Thanks!