### PR TITLE
Fix for issue #173

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Change History
 1.8.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix broken RichText fields on Plone 5.1.x.
+  [alecpm]
 
 
 1.8.6 (2019-07-29)

--- a/Products/PloneFormGen/content/fields.py
+++ b/Products/PloneFormGen/content/fields.py
@@ -1015,6 +1015,24 @@ class HtmlTextField(TextField):
     def getContentType(self, instance, fromBaseUnit=True):
         return 'text/html'
 
+    def text_accessor(self):
+        return self.get(self)
+
+    def raw_text_accessor(self):
+        return self.getRaw(self)
+
+    def getAccessor(self, instance):
+        accessor = super(HtmlTextField, self).getAccessor(instance)
+        if accessor is None:
+            return self.text_accessor
+        return accessor
+
+    def getEditAccessor(self, instance):
+        accessor = super(HtmlTextField, self).getEditAccessor(instance)
+        if accessor is None:
+            return self.raw_text_accessor
+        return accessor
+
 
 class FGRichTextField(BaseFormField):
     """ Rich-text (visual editor) field """


### PR DESCRIPTION
This overrides the `HtmlTextField` `getEditAccessor` and `getAccessor` methods to work with the new `TinyMCEWidget` by returning accessor methods which use the persistent field itself as the accessor context.