### PR TITLE
Backport uninstall profile to 1.7.x

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,10 +4,13 @@ Change History
 1.7.26 (unreleased)
 -------------------
 
-
 - Only test on Plone 4.3 and Python 2.7.
   It might still work on Plone 4.1 and 4.2 and Python 2.6, but the effort to keep the tests running is not worth it.
   [maurits]
+
+- Cherry-picked the uninstall-profile commit from smcmahon and the fix from maurits.
+  Further fix uninstall function in order to make it compatible with plone 4
+  [mathias.leimgruber]
 
 - Add uninstall profile and setuphandler. Make Plone 5.1 happy.
   [smcmahon]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,9 +4,13 @@ Change History
 1.7.26 (unreleased)
 -------------------
 
+
 - Only test on Plone 4.3 and Python 2.7.
   It might still work on Plone 4.1 and 4.2 and Python 2.6, but the effort to keep the tests running is not worth it.
   [maurits]
+
+- Add uninstall profile and setuphandler. Make Plone 5.1 happy.
+  [smcmahon]
 
 
 1.7.25 (2018-12-17)

--- a/Products/PloneFormGen/configure.zcml
+++ b/Products/PloneFormGen/configure.zcml
@@ -112,6 +112,15 @@
       />
 
   <gs:registerProfile
+      name="uninstall"
+      title="PloneFormGen"
+      directory="profiles/uninstall"
+      description="Uninstalls the PloneFormGen add-on."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      post_handler=".setuphandlers.uninstall"
+      />
+
+  <gs:registerProfile
       name="loadtest"
       title="PloneFormGen load test fixtures"
       directory="profiles/loadtest"

--- a/Products/PloneFormGen/profiles/uninstall/actionicons.xml
+++ b/Products/PloneFormGen/profiles/uninstall/actionicons.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<action-icons>
+ <action-icon category="controlpanel"
+              action_id="PloneFormGen"
+              remove="true" />
+</action-icons>

--- a/Products/PloneFormGen/profiles/uninstall/actionicons.xml
+++ b/Products/PloneFormGen/profiles/uninstall/actionicons.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<action-icons>
- <action-icon category="controlpanel"
-              action_id="PloneFormGen"
-              remove="true" />
-</action-icons>

--- a/Products/PloneFormGen/profiles/uninstall/actions.xml
+++ b/Products/PloneFormGen/profiles/uninstall/actions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <object name="object_buttons" meta_type="CMF Action Category">
+  <object name="export" meta_type="CMF Action" i18n:domain="plone">
+   <property name="title" i18n:translate="">Export</property>
+   <property name="description" i18n:translate=""></property>
+   <property
+      name="url_expr">string:${object_url}/@@export-form-folder</property>
+   <property name="icon_expr"></property>
+   <property
+      name="available_expr">python:object.meta_type in ('FormFolder')</property>
+   <property name="permissions">
+    <element value="Manage portal"/>
+   </property>
+   <property name="visible">True</property>
+  </object>
+  <object name="import" meta_type="CMF Action" i18n:domain="plone">
+   <property name="title" i18n:translate="">Import</property>
+   <property name="description" i18n:translate=""></property>
+   <property
+      name="url_expr">string:${object_url}/@@import-form-folder</property>
+   <property name="icon_expr"></property>
+   <property
+      name="available_expr">python:object.meta_type in ('FormFolder')</property>
+   <property name="permissions">
+    <element value="Manage portal"/>
+   </property>
+   <property name="visible">True</property>
+  </object>
+ </object>
+</object>

--- a/Products/PloneFormGen/profiles/uninstall/controlpanel.xml
+++ b/Products/PloneFormGen/profiles/uninstall/controlpanel.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="portal_controlpanel">
+ <configlet title="PloneFormGen" action_id="PloneFormGen" appId="PloneFormGen"
+    remove="true" />
+</object>

--- a/Products/PloneFormGen/profiles/uninstall/propertiestool.xml
+++ b/Products/PloneFormGen/profiles/uninstall/propertiestool.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<object name="portal_properties">
+ <object name="navtree_properties" >
+  <property name="metaTypesNotToList" type="lines" purge="False">
+   <element value="FormSelectionField" remove="true" />
+   <element value="FormMultiSelectionField" remove="true" />
+   <element value="FormLabelField" remove="true" />
+   <element value="FormDateField" remove="true" />
+   <element value="FormLinesField" remove="true" />
+   <element value="FormIntegerField" remove="true" />
+   <element value="FormBooleanField" remove="true" />
+   <element value="FormPasswordField" remove="true" />
+   <element value="FormFixedPointField" remove="true" />
+   <element value="FormStringField" remove="true" />
+   <element value="FormTextField" remove="true" />
+   <element value="FormRichTextField" remove="true" />
+   <element value="FormRichLabelField" remove="true" />
+   <element value="FormFileField" remove="true" />
+   <element value="FormLikertField" remove="true" />
+   <element value="FormSaveDataAdapter" remove="true" />
+   <element value="FormMailerAdapter" remove="true" />
+   <element value="FormCustomScriptAdapter" remove="true" />
+   <element value="FormThanksPage" remove="true" />
+   <element value="FieldsetFolder" remove="true" />
+   <element value="FormCaptchaField" remove="true" />
+   <element value="FieldsetStart" remove="true" />
+   <element value="FieldsetEnd" remove="true" />
+  </property>
+ </object>
+ <object name="site_properties" >
+  <property name="types_not_searched" type="lines" purge="False">
+   <element value="FormSelectionField" remove="true" />
+   <element value="FormMultiSelectionField" remove="true" />
+   <element value="FormLabelField" remove="true" />
+   <element value="FormDateField" remove="true" />
+   <element value="FormLinesField" remove="true" />
+   <element value="FormIntegerField" remove="true" />
+   <element value="FormBooleanField" remove="true" />
+   <element value="FormPasswordField" remove="true" />
+   <element value="FormFixedPointField" remove="true" />
+   <element value="FormStringField" remove="true" />
+   <element value="FormTextField" remove="true" />
+   <element value="FormRichTextField" remove="true" />
+   <element value="FormRichLabelField" remove="true" />
+   <element value="FormFileField" remove="true" />
+   <element value="FormLikertField" remove="true" />
+   <element value="FormSaveDataAdapter" remove="true" />
+   <element value="FormMailerAdapter" remove="true" />
+   <element value="FormCustomScriptAdapter" remove="true" />
+   <element value="FormThanksPage" remove="true" />
+   <element value="FieldsetFolder" remove="true" />
+   <element value="FormCaptchaField" remove="true" />
+   <element value="FieldsetStart" remove="true" />
+   <element value="FieldsetEnd" remove="true" />
+  </property>
+ </object>
+</object>

--- a/Products/PloneFormGen/profiles/uninstall/skins.xml
+++ b/Products/PloneFormGen/profiles/uninstall/skins.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_skins">
+ <skin-path name="*">
+  <layer name="PloneFormGen" remove="true" />
+ </skin-path>
+</object>

--- a/Products/PloneFormGen/profiles/uninstall/types.xml
+++ b/Products/PloneFormGen/profiles/uninstall/types.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+ <object name="FieldsetFolder" remove="true" />
+ <object name="FormBooleanField" remove="true" />
+ <object name="FormCaptchaField" remove="true" />
+ <object name="FormCustomScriptAdapter" remove="true" />
+ <object name="FormDateField" remove="true" />
+ <object name="FormFileField" remove="true" />
+ <object name="FormFixedPointField" remove="true" />
+ <object name="FormFolder" remove="true" />
+ <object name="FormIntegerField" remove="true" />
+ <object name="FormLabelField" remove="true" />
+ <object name="FormLikertField" remove="true" />
+ <object name="FormLinesField" remove="true" />
+ <object name="FormMailerAdapter" remove="true" />
+ <object name="FormMultiSelectionField" remove="true" />
+ <object name="FormPasswordField" remove="true" />
+ <object name="FormRichLabelField" remove="true" />
+ <object name="FormRichTextField" remove="true" />
+ <object name="FormSaveDataAdapter" remove="true" />
+ <object name="FormSelectionField" remove="true" />
+ <object name="FormStringField" remove="true" />
+ <object name="FormTextField" remove="true" />
+ <object name="FormThanksPage" remove="true" />
+ <object name="FieldsetStart" remove="true" />
+ <object name="FieldsetEnd" remove="true" />
+</object>

--- a/Products/PloneFormGen/setuphandlers.py
+++ b/Products/PloneFormGen/setuphandlers.py
@@ -1,6 +1,8 @@
 from zope.component import queryMultiAdapter
 from zope.interface import implements
 
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import INonInstallable
 
@@ -125,7 +127,10 @@ def uninstall(portal_setup, reinstall=False):
     """Uninstall script"""
 
     if not reinstall:
-        portal = portal_setup.aq_parent
-        portal.manage_delObjects(['formgen_tool'])
-
-        portal.portal_properties.manage_delObjects(['ploneformgen_properties'])
+        portal = aq_parent(aq_inner(portal_setup))
+        tool_id = 'formgen_tool'
+        if tool_id in portal:
+            portal.manage_delObjects([tool_id])
+        prop_id = 'ploneformgen_properties'
+        if prop_id in portal.portal_properties:
+            portal.portal_properties.manage_delObjects([prop_id])

--- a/Products/PloneFormGen/setuphandlers.py
+++ b/Products/PloneFormGen/setuphandlers.py
@@ -8,18 +8,17 @@ from Products.PloneFormGen.config import PROPERTY_SHEET_NAME, \
     DEFAULT_MAILTEMPLATE_BODY, EXTRA_ALLOWED
 
 from Products.PloneFormGen.interfaces.field import IPloneFormGenField
-from Products.PloneFormGen.interfaces.actionAdapter import \
-  IPloneFormGenActionAdapter
-from Products.PloneFormGen.interfaces.fieldset import \
-  IPloneFormGenFieldset
-from Products.PloneFormGen.interfaces.thanksPage import \
-  IPloneFormGenThanksPage
+from Products.PloneFormGen.interfaces.actionAdapter import IPloneFormGenActionAdapter
+from Products.PloneFormGen.interfaces.fieldset import IPloneFormGenFieldset
+from Products.PloneFormGen.interfaces.thanksPage import IPloneFormGenThanksPage
+
 
 class HiddenProfiles(object):
     implements(INonInstallable)
 
     def getNonInstallableProfiles(self):
-        return [u'Products.PloneFormGen:loadtest',]
+        return [u'Products.PloneFormGen:loadtest']
+
 
 def update_kupu_resources(out, site):
     """ At the time of this writing, kupu's GS export/import
@@ -41,13 +40,16 @@ def update_kupu_resources(out, site):
             # kupu's resource list can accumulate old, no longer valid types;
             # it will throw an exception if we try to resave them.
             # So, let's clean the list.
-            valid_types = dict([ (t.id, 1) for t in typesTool.listTypeInfo()])
+            valid_types = dict([(t.id, 1) for t in typesTool.listTypeInfo()])
             linkable = [pt for pt in linkable if pt in valid_types]
 
             linkable.append('FormFolder')
-            kupuTool.updateResourceTypes(({'resource_type' : 'linkable',
-                                           'old_type'      : 'linkable',
-                                           'portal_types'  :  linkable},))
+            kupuTool.updateResourceTypes(({
+                'resource_type': 'linkable',
+                'old_type': 'linkable',
+                'portal_types': linkable,
+            },))
+
 
 def safe_add_purgeable_properties(out, site):
     """ In order to avoid a possible "feature" regression and
@@ -111,10 +113,19 @@ def importVarious(context):
 
     # now, use our hard-won type lists to set allowed types
     ptt.getTypeInfo('FormFolder').manage_changeProperties(
-      allowed_content_types = fields + adapters + fieldsets + thankers + \
-        EXTRA_ALLOWED
-      )
+        allowed_content_types=fields + adapters + fieldsets + thankers + EXTRA_ALLOWED
+    )
     for fs in fieldsets:
         ptt.getTypeInfo(fs).manage_changeProperties(
-          allowed_content_types = fields
-          )
+            allowed_content_types=fields
+        )
+
+
+def uninstall(portal_setup, reinstall=False):
+    """Uninstall script"""
+
+    if not reinstall:
+        portal = portal_setup.aq_parent
+        portal.manage_delObjects(['formgen_tool'])
+
+        portal.portal_properties.manage_delObjects(['ploneformgen_properties'])

--- a/Products/PloneFormGen/setuphandlers.py
+++ b/Products/PloneFormGen/setuphandlers.py
@@ -134,3 +134,9 @@ def uninstall(portal_setup, reinstall=False):
         prop_id = 'ploneformgen_properties'
         if prop_id in portal.portal_properties:
             portal.portal_properties.manage_delObjects([prop_id])
+
+        actionicons = portal.portal_actionicons
+        result = actionicons.queryActionIcon('controlpanel', 'PloneFormGen')
+
+        if result is not None:
+            actionicons.removeActionIcon('controlpanel', 'PloneFormGen')

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(name='Products.PloneFormGen',
           'setuptools',
           'Products.Archetypes>=1.7.14',  # placeholder support
           'Products.CMFPlone>=4.1',
+          'Products.GenericSetup>=1.8.2',
           'Products.TALESField>=1.1.3',
           'Products.TemplateFields>=1.2.4',
           'Products.PythonField>=1.1.3',


### PR DESCRIPTION
I cherry-picked two commits:
- 8e9992e (Uninstall profile)
- c463a82 (Fix for uninstall function)

Further I implemented the removal of the actionicon from PloneFormGen using the uninstall function, since the GS actionicons.xml did not work for all plone 4.3.x versions. 