### PR TITLE
Only apply quickedit bundle js and styles to the quickedit form

### DIFF
--- a/Products/PloneFormGen/profiles/default/metadata.xml
+++ b/Products/PloneFormGen/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>190</version>
+  <version>191</version>
   <dependencies>
       <dependency>profile-Products.ATContentTypes:base</dependency>
 <!--

--- a/Products/PloneFormGen/profiles/default/registry.xml
+++ b/Products/PloneFormGen/profiles/default/registry.xml
@@ -20,7 +20,7 @@
         <value key="resources">
             <element>pfgquickedit</element>
         </value>
-        <value key="expression">python: object.portal_type == 'FormFolder' and member is not None</value>
+        <value key="expression">python: '/quickedit' in request.get('URL0', '') and object.portal_type == 'FormFolder' and member is not None</value>
         <value key="enabled">True</value>
         <value key="compile">False</value>
         <value key="jscompilation">++plone++pfgquickedit/quickedit-min.js</value>

--- a/Products/PloneFormGen/upgrades.zcml
+++ b/Products/PloneFormGen/upgrades.zcml
@@ -57,5 +57,12 @@
         handler=".upgrades.upgrade_to_190"
         />
 
+    <genericsetup:upgradeDepends
+        source="190"
+        destination="191"
+        profile="Products.PloneFormGen:default"
+        title="Import registry.xml"
+        import_steps="plone.app.registry"
+        />
 
 </configure>


### PR DESCRIPTION
Currently the quckedit bundle of JS and CSS is included on all `Form Folder` content when viewed by a logged in user. It should only be loaded for the `quickedit` view. The check I've added seems a little lame, but it's the same form as the one used by `eea.facetedsearch` for the `faceted-edit` bundle. This fixes some significant styling issues on PFG forms when viewed by logged in users.