### PR TITLE
fix breakage with plone security hotfix 20210518

### DIFF
--- a/Products/PloneFormGen/skins/PloneFormGen/fg_edit_macros_p3.pt
+++ b/Products/PloneFormGen/skins/PloneFormGen/fg_edit_macros_p3.pt
@@ -180,15 +180,16 @@
               Turn 'persistent_' variables from forms (GET/POST) persistent
             </tal:comment>
             <tal:env repeat="env request/form">
-              <input type="hidden"
-                     name="key"
-                     value="value"
-                     tal:define="key env;
-                                 value request/?env"
-                     tal:condition="python:key.startswith('persistent_')"
-                     tal:attributes="name string:form_env.${key}:record;
-                                     value value"
-                     />
+              <tal:block define="key env"
+                         condition="python:key.startswith('persistent_')">
+                <input type="hidden"
+                       name="key"
+                       value="value"
+                       tal:define="value request/?env"
+                       tal:attributes="name string:form_env.${key}:record;
+                                       value value"
+                        />
+              </tal:block>
             </tal:env>
 
             <tal:comment replace="nothing">


### PR DESCRIPTION
analogue to https://github.com/smcmahon/Products.PloneFormGen/pull/229
This adds the fix for the 1.7 version of Products.PloneFormGen

Tested on a test setup (Plone 4.3.19 with 1.7-maintenance branch) with existing forms, this fixes the validation errors
- without fix: instead of validation warning you get a 'this page does not seem to exist' (404)
- with fix: you get one or more validation messages on the form fields, form can be sublitted when validation errors are fixed